### PR TITLE
Refactor email otp authenticator to handle multi attribute login

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
@@ -239,17 +239,16 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                 response, request, context);
     }
 
-    private AuthenticatedUser resolveUserFromUserStore(AuthenticatedUser authenticatedUserFromContext)
+    private AuthenticatedUser resolveUserFromUserStore(AuthenticatedUser authenticatedUser)
             throws AuthenticationFailedException {
 
-        User user;
-        user = getUser(authenticatedUserFromContext);
+        User user = getUser(authenticatedUser);
         if (user != null) {
-            authenticatedUserFromContext = new AuthenticatedUser(user);
+            authenticatedUser = new AuthenticatedUser(user);
         } else {
-            authenticatedUserFromContext = null;
+            authenticatedUser = null;
         }
-        return authenticatedUserFromContext;
+        return authenticatedUser;
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
@@ -211,7 +211,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                 boolean isUserResolved = FrameworkUtils.getIsUserResolved(context);
                 if (!isUserResolved) {
                     // If the user is not resolved, we need to resolve the user.
-                    authenticatedUserFromContext = resolveUserFromUserStore(authenticatedUserFromContext);
+                    authenticatedUserFromContext = resolveUserFromUserStore(authenticatedUserFromContext).get();;
                 }
             }
         }
@@ -266,16 +266,11 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                 response, request, context);
     }
 
-    private AuthenticatedUser resolveUserFromUserStore(AuthenticatedUser authenticatedUser)
+    private Optional<AuthenticatedUser> resolveUserFromUserStore(AuthenticatedUser authenticatedUser)
             throws AuthenticationFailedException {
 
-        User user = getUser(authenticatedUser);
-        if (user != null) {
-            authenticatedUser = new AuthenticatedUser(user);
-        } else {
-            authenticatedUser = null;
-        }
-        return authenticatedUser;
+        return Optional.ofNullable(getUser(authenticatedUser))
+                .map(AuthenticatedUser::new);
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
@@ -211,7 +211,8 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                 boolean isUserResolved = FrameworkUtils.getIsUserResolved(context);
                 if (!isUserResolved) {
                     // If the user is not resolved, we need to resolve the user.
-                    authenticatedUserFromContext = resolveUserFromUserStore(authenticatedUserFromContext).get();;
+                    authenticatedUserFromContext = resolveUserFromUserStore(authenticatedUserFromContext)
+                            .orElse(null);
                 }
             }
         }

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
@@ -181,11 +181,10 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
             }
         } else {
             if (isPreviousIdPAuthenticationFlowHandler(context)) {
-                user = getUser(authenticatedUserFromContext);
-                if (user != null) {
-                    authenticatedUserFromContext = new AuthenticatedUser(user);
-                } else {
-                    authenticatedUserFromContext = null;
+                boolean isUserResolved = FrameworkUtils.getIsUserResolved(context);
+                if (!isUserResolved) {
+                    // If the user is not resolved, we need to resolve the user.
+                    authenticatedUserFromContext = resolveUserFromUserStore(authenticatedUserFromContext);
                 }
             }
         }
@@ -238,6 +237,19 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
         }
         redirectToEmailOTPLoginPage(authenticatedUserFromContext.getUserName(), email, applicationTenantDomain,
                 response, request, context);
+    }
+
+    private AuthenticatedUser resolveUserFromUserStore(AuthenticatedUser authenticatedUserFromContext)
+            throws AuthenticationFailedException {
+
+        User user;
+        user = getUser(authenticatedUserFromContext);
+        if (user != null) {
+            authenticatedUserFromContext = new AuthenticatedUser(user);
+        } else {
+            authenticatedUserFromContext = null;
+        }
+        return authenticatedUserFromContext;
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticatorTest.java
@@ -43,6 +43,7 @@ import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants;
 import org.wso2.carbon.identity.local.auth.emailotp.internal.AuthenticatorDataHolder;
 import org.wso2.carbon.identity.local.auth.emailotp.util.AuthenticatorUtils;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.common.User;
@@ -92,6 +93,7 @@ public class EmailOTPAuthenticatorTest {
     private ClaimMetadataManagementService claimMetadataManagementService;
     private IdentityGovernanceService identityGovernanceService;
     private CaptchaDataHolder captchaDataHolder;
+    private MultiAttributeLoginService multiAttributeLoginService;
 
     private static final String USERNAME = "abc@gmail.com";
     private static final String EMAIL_ADDRESS = "abc@gmail.com";
@@ -122,6 +124,7 @@ public class EmailOTPAuthenticatorTest {
         claimMetadataManagementService = mock(ClaimMetadataManagementService.class);
         identityGovernanceService = mock(IdentityGovernanceService.class);
         captchaDataHolder = mock(CaptchaDataHolder.class);
+        multiAttributeLoginService = mock(MultiAttributeLoginService.class);
 
         staticConfigurationFacade = mockStatic(ConfigurationFacade.class);
         frameworkUtils = mockStatic(FrameworkUtils.class);
@@ -196,7 +199,7 @@ public class EmailOTPAuthenticatorTest {
         when(userStoreManager.getUserClaimValues(any(), any(), any())).thenReturn(claimMap);
         when(fileBasedConfigurationBuilder.getAuthenticatorBean(anyString())).thenReturn(authenticatorConfig);
         userCoreUtil.when(UserCoreUtil::getDomainFromThreadLocal).thenReturn(DEFAULT_USER_STORE);
-
+        mockMultiAttributeLoginService();
         status = emailOTPAuthenticator.process(httpServletRequest, httpServletResponse, context);
         Assert.assertEquals(status, AuthenticatorFlowStatus.INCOMPLETE);
         Assert.assertTrue((Boolean.parseBoolean(String.valueOf(context.getProperty(
@@ -236,6 +239,7 @@ public class EmailOTPAuthenticatorTest {
         when(FrameworkUtils.preprocessUsername(USERNAME, context)).thenReturn(USERNAME + "@" + TENANT_DOMAIN);
         when(CaptchaDataHolder.getInstance()).thenReturn(captchaDataHolder);
         AuthenticatorDataHolder.setIdentityGovernanceService(identityGovernanceService);
+        mockMultiAttributeLoginService();
 
         AuthenticatorFlowStatus status = emailOTPAuthenticator.process(httpServletRequest, httpServletResponse,
                 context);
@@ -271,6 +275,12 @@ public class EmailOTPAuthenticatorTest {
         ApplicationConfig applicationConfig = mock(ApplicationConfig.class);
         when(applicationConfig.isSaaSApp()).thenReturn(false);
         context.getSequenceConfig().setApplicationConfig(applicationConfig);
+    }
+
+    private void mockMultiAttributeLoginService() {
+        when(FrameworkServiceDataHolder.getInstance()).thenReturn(frameworkServiceDataHolder);
+        when(frameworkServiceDataHolder.getMultiAttributeLoginService()).thenReturn(multiAttributeLoginService);
+        when(multiAttributeLoginService.isEnabled(anyString())).thenReturn(false);
     }
 
     @AfterMethod

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticatorTest.java
@@ -280,6 +280,7 @@ public class EmailOTPAuthenticatorTest {
     }
 
     private void mockMultiAttributeLoginService() {
+
         when(FrameworkServiceDataHolder.getInstance()).thenReturn(frameworkServiceDataHolder);
         when(frameworkServiceDataHolder.getMultiAttributeLoginService()).thenReturn(multiAttributeLoginService);
         when(multiAttributeLoginService.isEnabled(anyString())).thenReturn(false);

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticatorTest.java
@@ -96,7 +96,6 @@ public class EmailOTPAuthenticatorTest {
     private ClaimMetadataManagementService claimMetadataManagementService;
     private IdentityGovernanceService identityGovernanceService;
     private CaptchaDataHolder captchaDataHolder;
-    private MultiAttributeLoginService multiAttributeLoginService;
 
     private static final String USERNAME = "abc@gmail.com";
     private static final String EMAIL_ADDRESS = "abc@gmail.com";
@@ -105,11 +104,6 @@ public class EmailOTPAuthenticatorTest {
     private static final String USER_STORE_DOMAIN = "PRIMARY";
     private static final String DEFAULT_USER_STORE = "DEFAULT";
     private static final String DUMMY_LOGIN_PAGE_URL = "dummyLoginPageURL";
-    private static final String DUMMY_OTP_PAGE_URL = "dummyOTPPageURL";
-    private static final String RECAPTCHA_PARAM = "&reCaptcha=true";
-    private static final String DUMMY_SESSION_DATA_KEY = "dummySessionDataKey";
-    private static final String SSO_LOGIN_RECAPTCHA_ENABLE_ALWAYS = "sso.login.recaptcha.enable.always";
-    private static final String SSO_LOGIN_RECAPTCHA_ENABLE = "sso.login.recaptcha.enable";
 
     @BeforeMethod
     public void setUp() {

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
         <encoder.wso2.import.version.range>[1.2.0, 2.0.0)</encoder.wso2.import.version.range>
 
         <carbon.kernel.version>4.9.0-m4</carbon.kernel.version>
-        <carbon.identity.framework.version>5.25.214</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.286</carbon.identity.framework.version>
         <carbon.identity.governance.version>1.8.40</carbon.identity.governance.version>
         <carbon.identity.handler.event.account.lock.version>1.8.2</carbon.identity.handler.event.account.lock.version>
         <carbon.extension.identity.helper.version>1.0.12</carbon.extension.identity.helper.version>

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
         <encoder.wso2.import.version.range>[1.2.0, 2.0.0)</encoder.wso2.import.version.range>
 
         <carbon.kernel.version>4.9.0-m4</carbon.kernel.version>
-        <carbon.identity.framework.version>5.25.286</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.287</carbon.identity.framework.version>
         <carbon.identity.governance.version>1.8.40</carbon.identity.governance.version>
         <carbon.identity.handler.event.account.lock.version>1.8.2</carbon.identity.handler.event.account.lock.version>
         <carbon.extension.identity.helper.version>1.0.12</carbon.extension.identity.helper.version>


### PR DESCRIPTION
## Purpose
- When multi attribute login is enabled, from the IDF hanlder the user is resolved using the multi attribute login service and set `isUserResolved : true` to the context.
- From these changes, the user is only resolved from the user store if the user is not resolved from the previous step when previous step is IDF. This is done to avoid the duplicate resolvings from the user store because user is already resolved in the IDF, when multi attribute login is enabled.


## Merge this after 
https://github.com/wso2/carbon-identity-framework/pull/4860