### PR TITLE
Add lockedReason and errorCode to account locked error url

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
@@ -910,7 +910,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
         }
         // Locked reason.
         String lockedReason = getLockedReason(authenticatedUser);
-        if (StringUtils.isNotEmpty(lockedReason)) {
+        if (StringUtils.isNotBlank(lockedReason)) {
             queryParams += AuthenticatorConstants.LOCKED_REASON_QUERY_PARAM + lockedReason;
         }
         queryParams += AuthenticatorConstants.ERROR_CODE_QUERY_PARAM + USER_IS_LOCKED;

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
@@ -63,6 +63,8 @@ public class AuthenticatorConstants {
             "&authFailure=true&authFailureMsg=user.account.locked";
     public static final String SCREEN_VALUE_QUERY_PARAM = "&screenValue=";
     public static final String UNLOCK_QUERY_PARAM = "&unlockTime=";
+    public static final String LOCKED_REASON_QUERY_PARAM = "&lockedReason=";
+    public static final String ERROR_CODE_QUERY_PARAM = "&errorCode=";
     public static final String RESEND_CODE_PARAM = "&resendCode=true";
     public static final String MULTI_OPTION_QUERY_PARAM = "multiOptionURI";
 
@@ -100,6 +102,7 @@ public class AuthenticatorConstants {
 
         public static final String EMAIL_CLAIM = "http://wso2.org/claims/emailaddress";
         public static final String ACCOUNT_UNLOCK_TIME_CLAIM = "http://wso2.org/claims/identity/unlockTime";
+        public static final String ACCOUNT_LOCKED_REASON_CLAIM = "http://wso2.org/claims/identity/lockedReason";
         public static final String OTP_BACKUP_CODES_CLAIM = "http://wso2.org/claims/identity/otpbackupcodes";
         public static final String EMAIL_OTP_FAILED_ATTEMPTS_CLAIM =
                 "http://wso2.org/claims/identity/failedEmailOtpAttempts";


### PR DESCRIPTION
When a user is locked following parameters are added to the URL if `showAuthFailureReason` is enabled
```
errorCode: 17003
lockedReason: MAX_ATTEMPTS_EXCEEDED
authFailure: true
authFailureMsg: user.account.locked
unlockTime: <unlockTime>
```

Related issue https://github.com/wso2/product-is/issues/16333