### PR TITLE
Change email OTP isNumeric field to isAlphanumeric

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
@@ -1416,14 +1416,14 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
             throws AuthenticationFailedException {
 
         try {
-            boolean useOnlyNumericChars = Boolean.parseBoolean(
+            boolean useAlphanumericChars = Boolean.parseBoolean(
                     AuthenticatorUtils.getEmailAuthenticatorConfig(
-                            AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_USE_NUMERIC_CHARS, tenantDomain));
-            if (useOnlyNumericChars) {
-                return AuthenticatorConstants.EMAIL_OTP_NUMERIC_CHAR_SET;
+                            AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_USE_ALPHANUMERIC_CHARS, tenantDomain));
+            if (useAlphanumericChars) {
+                return AuthenticatorConstants.EMAIL_OTP_UPPER_CASE_ALPHABET_CHAR_SET +
+                        AuthenticatorConstants.EMAIL_OTP_NUMERIC_CHAR_SET;
             }
-            return AuthenticatorConstants.EMAIL_OTP_UPPER_CASE_ALPHABET_CHAR_SET +
-                    AuthenticatorConstants.EMAIL_OTP_NUMERIC_CHAR_SET;
+            return AuthenticatorConstants.EMAIL_OTP_NUMERIC_CHAR_SET;
         } catch (EmailOtpAuthenticatorServerException exception) {
             throw handleAuthErrorScenario(AuthenticatorConstants.ErrorMessages.ERROR_CODE_ERROR_GETTING_CONFIG,
                     context);

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/connector/EmailOTPAuthenticatorConfigImpl.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/connector/EmailOTPAuthenticatorConfigImpl.java
@@ -74,8 +74,8 @@ public class EmailOTPAuthenticatorConfigImpl implements IdentityConnectorConfig 
         nameMapping.put(AuthenticatorConstants.ConnectorConfig.ENABLE_BACKUP_CODES,
                 "Enable authenticate with backup codes");
         nameMapping.put(AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_LENGTH, "Email OTP token length");
-        nameMapping.put(AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_USE_NUMERIC_CHARS,
-                "Use only numeric characters for OTP token");
+        nameMapping.put(AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_USE_ALPHANUMERIC_CHARS,
+                "Use alphanumeric characters for OTP token");
         return nameMapping;
     }
 
@@ -89,8 +89,8 @@ public class EmailOTPAuthenticatorConfigImpl implements IdentityConnectorConfig 
                 "Allow users to login with backup codes");
         descriptionMapping.put(AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_LENGTH,
                 "Number of characters in the OTP token");
-        descriptionMapping.put(AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_USE_NUMERIC_CHARS,
-                "Enabling this will only generate OTP tokens with 0-9 characters");
+        descriptionMapping.put(AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_USE_ALPHANUMERIC_CHARS,
+                "Enabling this will generate OTP tokens with 0-9 and alphabetic characters");
         return descriptionMapping;
     }
 
@@ -101,7 +101,7 @@ public class EmailOTPAuthenticatorConfigImpl implements IdentityConnectorConfig 
         properties.add(AuthenticatorConstants.ConnectorConfig.OTP_EXPIRY_TIME);
         properties.add(AuthenticatorConstants.ConnectorConfig.ENABLE_BACKUP_CODES);
         properties.add(AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_LENGTH);
-        properties.add(AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_USE_NUMERIC_CHARS);
+        properties.add(AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_USE_ALPHANUMERIC_CHARS);
         return properties.toArray(new String[0]);
     }
 
@@ -111,14 +111,14 @@ public class EmailOTPAuthenticatorConfigImpl implements IdentityConnectorConfig 
         // 5 minutes in seconds.
         String otpExpiryTime = "300";
         String useBackupCodes = "false";
-        String useNumericChars = "true";
+        String useAlphanumericChars = "false";
         String otpLength = Integer.toString(AuthenticatorConstants.DEFAULT_OTP_LENGTH);
 
         String otpExpiryTimeProperty = IdentityUtil.getProperty(AuthenticatorConstants.ConnectorConfig.OTP_EXPIRY_TIME);
         String useBackupCodesProperty = IdentityUtil.getProperty(
                 AuthenticatorConstants.ConnectorConfig.ENABLE_BACKUP_CODES);
-        String useNumericCharsProperty = IdentityUtil.getProperty(
-                AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_USE_NUMERIC_CHARS);
+        String useAlphanumericCharsProperty = IdentityUtil.getProperty(
+                AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_USE_ALPHANUMERIC_CHARS);
         String otpLengthProperty = IdentityUtil.getProperty(AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_LENGTH);
 
         if (StringUtils.isNotBlank(otpExpiryTimeProperty)) {
@@ -127,8 +127,8 @@ public class EmailOTPAuthenticatorConfigImpl implements IdentityConnectorConfig 
         if (StringUtils.isNotBlank(useBackupCodesProperty)) {
             useBackupCodes = useBackupCodesProperty;
         }
-        if (StringUtils.isNotBlank(useNumericCharsProperty)) {
-            useNumericChars = useNumericCharsProperty;
+        if (StringUtils.isNotBlank(useAlphanumericCharsProperty)) {
+            useAlphanumericChars = useAlphanumericCharsProperty;
         }
         if (StringUtils.isNotBlank(otpLengthProperty)) {
             otpLength = otpLengthProperty;
@@ -136,7 +136,8 @@ public class EmailOTPAuthenticatorConfigImpl implements IdentityConnectorConfig 
         Map<String, String> defaultProperties = new HashMap<>();
         defaultProperties.put(AuthenticatorConstants.ConnectorConfig.OTP_EXPIRY_TIME, otpExpiryTime);
         defaultProperties.put(AuthenticatorConstants.ConnectorConfig.ENABLE_BACKUP_CODES, useBackupCodes);
-        defaultProperties.put(AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_USE_NUMERIC_CHARS, useNumericChars);
+        defaultProperties.put(AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_USE_ALPHANUMERIC_CHARS,
+                useAlphanumericChars);
         defaultProperties.put(AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_LENGTH, otpLength);
 
         Properties properties = new Properties();

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/connector/EmailOTPAuthenticatorConfigImpl.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/connector/EmailOTPAuthenticatorConfigImpl.java
@@ -102,6 +102,7 @@ public class EmailOTPAuthenticatorConfigImpl implements IdentityConnectorConfig 
         properties.add(AuthenticatorConstants.ConnectorConfig.ENABLE_BACKUP_CODES);
         properties.add(AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_LENGTH);
         properties.add(AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_USE_ALPHANUMERIC_CHARS);
+        properties.add(AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_USE_NUMERIC_CHARS);
         return properties.toArray(new String[0]);
     }
 
@@ -112,6 +113,7 @@ public class EmailOTPAuthenticatorConfigImpl implements IdentityConnectorConfig 
         String otpExpiryTime = "300";
         String useBackupCodes = "false";
         String useAlphanumericChars = "false";
+        String useNumericChars = "true";
         String otpLength = Integer.toString(AuthenticatorConstants.DEFAULT_OTP_LENGTH);
 
         String otpExpiryTimeProperty = IdentityUtil.getProperty(AuthenticatorConstants.ConnectorConfig.OTP_EXPIRY_TIME);
@@ -119,6 +121,8 @@ public class EmailOTPAuthenticatorConfigImpl implements IdentityConnectorConfig 
                 AuthenticatorConstants.ConnectorConfig.ENABLE_BACKUP_CODES);
         String useAlphanumericCharsProperty = IdentityUtil.getProperty(
                 AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_USE_ALPHANUMERIC_CHARS);
+        String useNumericCharsProperty = IdentityUtil.getProperty(
+                AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_USE_NUMERIC_CHARS);
         String otpLengthProperty = IdentityUtil.getProperty(AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_LENGTH);
 
         if (StringUtils.isNotBlank(otpExpiryTimeProperty)) {
@@ -130,6 +134,9 @@ public class EmailOTPAuthenticatorConfigImpl implements IdentityConnectorConfig 
         if (StringUtils.isNotBlank(useAlphanumericCharsProperty)) {
             useAlphanumericChars = useAlphanumericCharsProperty;
         }
+        if (StringUtils.isNotBlank(useNumericCharsProperty)) {
+            useNumericChars = useNumericCharsProperty;
+        }
         if (StringUtils.isNotBlank(otpLengthProperty)) {
             otpLength = otpLengthProperty;
         }
@@ -138,6 +145,7 @@ public class EmailOTPAuthenticatorConfigImpl implements IdentityConnectorConfig 
         defaultProperties.put(AuthenticatorConstants.ConnectorConfig.ENABLE_BACKUP_CODES, useBackupCodes);
         defaultProperties.put(AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_USE_ALPHANUMERIC_CHARS,
                 useAlphanumericChars);
+        defaultProperties.put(AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_USE_NUMERIC_CHARS, useNumericChars);
         defaultProperties.put(AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_LENGTH, otpLength);
 
         Properties properties = new Properties();

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
@@ -99,7 +99,7 @@ public class AuthenticatorConstants {
         public static final String OTP_EXPIRY_TIME = "EmailOTP.ExpiryTime";
         public static final String ENABLE_BACKUP_CODES = "EmailOTP.EnableBackupCodes";
         public static final String EMAIL_OTP_LENGTH = "EmailOTP.OTPLength";
-        public static final String EMAIL_OTP_USE_ALPHANUMERIC_CHARS = "EmailOTP.OtpRegex.UseAlphanumericChars";
+        public static final String EMAIL_OTP_USE_ALPHANUMERIC_CHARS = "EmailOTP.UseAlphanumericChars";
         public static final String EMAIL_OTP_USE_NUMERIC_CHARS = "EmailOTP.OtpRegex.UseNumericChars";
     }
 

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
@@ -100,6 +100,7 @@ public class AuthenticatorConstants {
         public static final String ENABLE_BACKUP_CODES = "EmailOTP.EnableBackupCodes";
         public static final String EMAIL_OTP_LENGTH = "EmailOTP.OTPLength";
         public static final String EMAIL_OTP_USE_ALPHANUMERIC_CHARS = "EmailOTP.OtpRegex.UseAlphanumericChars";
+        public static final String EMAIL_OTP_USE_NUMERIC_CHARS = "EmailOTP.OtpRegex.UseNumericChars";
     }
 
     /**

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
@@ -99,7 +99,7 @@ public class AuthenticatorConstants {
         public static final String OTP_EXPIRY_TIME = "EmailOTP.ExpiryTime";
         public static final String ENABLE_BACKUP_CODES = "EmailOTP.EnableBackupCodes";
         public static final String EMAIL_OTP_LENGTH = "EmailOTP.OTPLength";
-        public static final String EMAIL_OTP_USE_NUMERIC_CHARS = "EmailOTP.OtpRegex.UseNumericChars";
+        public static final String EMAIL_OTP_USE_ALPHANUMERIC_CHARS = "EmailOTP.OtpRegex.UseAlphanumericChars";
     }
 
     /**


### PR DESCRIPTION
**Purpose**

> In the email OTP connector config, the config is avilable to configure whether the OTP is numeric. Which is the default behaviour. The newly added support is for OTP as alphanumeric. Hence the config is getting changed to whether the OTP is alphanumeric.

Resolves https://github.com/wso2/product-is/issues/17073
