### PR TITLE
Fix email otp is not receiving issue when multi attribute login is enabled

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
@@ -213,7 +213,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
 
             // When username is obtained through IDF page and the user is not yet set in the context.
             AuthenticatedUser authenticatedUser = resolveUser(request, context);
-            user = getUser(authenticatedUser);
+            user = getUser(authenticatedUser, context);
             if ((resolveUsernameFromRequest(request) != null) && (user == null)) {
                 context.setProperty(IS_USER_NAME_RESOLVED, false);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,7 @@
         <encoder.wso2.import.version.range>[1.2.0, 2.0.0)</encoder.wso2.import.version.range>
 
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
-        <carbon.identity.framework.version>7.0.96</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.0.106</carbon.identity.framework.version>
         <carbon.identity.governance.version>1.8.40</carbon.identity.governance.version>
         <carbon.identity.handler.event.account.lock.version>1.8.2</carbon.identity.handler.event.account.lock.version>
         <carbon.extension.identity.helper.version>1.0.12</carbon.extension.identity.helper.version>


### PR DESCRIPTION
## Purpose
- To fix the issue , the email otp is not receiving when multi attribute login is enabled and email otp as first factor.

### Related issue
https://github.com/wso2/product-is/issues/20033

## When this PR needs to merged
- This should be merged after https://github.com/wso2/carbon-identity-framework/pull/5588

