### PR TITLE
Fix user claims not being available for federated users

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
@@ -56,6 +56,7 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.handler.notification.NotificationConstants;
 import org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants;
 import org.wso2.carbon.identity.local.auth.emailotp.exception.EmailOtpAuthenticatorServerException;
 import org.wso2.carbon.identity.local.auth.emailotp.internal.AuthenticatorDataHolder;
@@ -920,6 +921,10 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
             throws AuthenticationFailedException {
 
         HashMap<String, Object> properties = new HashMap<>();
+        if (user.isFederatedUser()) {
+            properties.put(NotificationConstants.IS_FEDERATED_USER, user.isFederatedUser());
+            properties.put(NotificationConstants.FEDERATED_USER_CLAIMS, user.getUserAttributes());
+        }
         properties.put(IdentityEventConstants.EventProperty.USER_NAME, user.getUserName());
         properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, user.getUserStoreDomain());
         properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, user.getTenantDomain());

--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
         <carbon.identity.governance.version>1.8.40</carbon.identity.governance.version>
         <carbon.identity.handler.event.account.lock.version>1.8.2</carbon.identity.handler.event.account.lock.version>
         <carbon.extension.identity.helper.version>1.0.12</carbon.extension.identity.helper.version>
-        <carbon.identity.event.handler.notification.version>1.7.12</carbon.identity.event.handler.notification.version>
+        <carbon.identity.event.handler.notification.version>1.8.17</carbon.identity.event.handler.notification.version>
         <owasp.encoder.version>1.2.0.wso2v1</owasp.encoder.version>
         <mockito-inline.version>3.8.0</mockito-inline.version>
 


### PR DESCRIPTION
## Purpose

For federated user, user claims will be added to the event properties and will be consumed from the event handler if the user is federated.

## Related PRs 

Depends on https://github.com/wso2-extensions/identity-event-handler-notification/pull/238