### PR TITLE
Set missing display name property to Auth Initiation Data

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
@@ -1756,6 +1756,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
 
         AuthenticatorData authenticatorData = new AuthenticatorData();
         authenticatorData.setName(getName());
+        authenticatorData.setDisplayName(getFriendlyName());
         String idpName = null;
         AuthenticatedUser authenticatedUserFromContext = null;
         if (context != null) {

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticatorTest.java
@@ -330,6 +330,9 @@ public class EmailOTPAuthenticatorTest {
         authenticatorParamMetadataList.add(usernameMetadata);
 
         Assert.assertEquals(authenticatorDataObj.getName(), AuthenticatorConstants.EMAIL_OTP_AUTHENTICATOR_NAME);
+        Assert.assertEquals(authenticatorDataObj.getDisplayName(),
+                AuthenticatorConstants.EMAIL_OTP_AUTHENTICATOR_FRIENDLY_NAME,
+                "Authenticator display name should match.");
         Assert.assertEquals(authenticatorDataObj.getAuthParams().size(), authenticatorParamMetadataList.size(),
                 "Size of lists should be equal.");
         Assert.assertEquals(authenticatorDataObj.getPromptType(),


### PR DESCRIPTION
Fixes the issue of not having the display name property in the auth initiation data during api based autehntication.

Related issue: https://github.com/wso2/product-is/issues/20219
