### PR TITLE
Adding remainingNumberOfEmailOtpAttempts parameter in the response upon an invalid EmailOTP attempt

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
@@ -39,6 +39,7 @@ public class AuthenticatorConstants {
     public static final String CODE_PARAM = "code.param";
     public static final String USER_PROMPT = "USER_PROMPT";
     public static final String AUTHENTICATOR_EMAIL_OTP = "authenticator.email.otp";
+    public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE = "account.lock.handler.enable";
 
     // OTP generation.
     public static final String EMAIL_OTP_UPPER_CASE_ALPHABET_CHAR_SET = "KIGXHOYSPRWCEFMVUQLZDNABJT";
@@ -74,6 +75,7 @@ public class AuthenticatorConstants {
     public static final String ERROR_CODE_QUERY_PARAM = "&errorCode=";
     public static final String RESEND_CODE_PARAM = "&resendCode=true";
     public static final String MULTI_OPTION_QUERY_PARAM = "multiOptionURI";
+    public static final String REMAINING_NUMBER_OF_EMAIL_OTP_ATTEMPTS_QUERY = "&remainingNumberOfEmailOtpAttempts=";
 
     // Endpoint URLs.
     public static final String EMAIL_OTP_AUTHENTICATION_ENDPOINT_URL = "EMAILOTPAuthenticationEndpointURL";
@@ -91,6 +93,7 @@ public class AuthenticatorConstants {
     public static final String USER_NAME = "username";
     public static final String DISPLAY_USER_NAME = "Username";
     public static final String IS_REDIRECT_TO_EMAIL_OTP = "isRedirectToEmailOTP";
+    public static final String CONF_SHOW_AUTH_FAILURE_REASON = "showAuthFailureReason";
 
     /**
      * Authenticator config related configurations.

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/util/AuthenticatorUtils.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/util/AuthenticatorUtils.java
@@ -39,6 +39,9 @@ import java.net.URISyntaxException;
 
 import javax.servlet.http.HttpServletRequest;
 
+import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.ACCOUNT_UNLOCK_TIME_PROPERTY;
+import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.FAILED_LOGIN_ATTEMPTS_PROPERTY;
+import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.LOGIN_FAIL_TIMEOUT_RATIO_PROPERTY;
 import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.EMAIL_OTP_AUTHENTICATION_ENDPOINT_URL;
 import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.EMAIL_OTP_AUTHENTICATION_ERROR_PAGE_URL;
 import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.EMAIL_OTP_PAGE;
@@ -169,6 +172,34 @@ public class AuthenticatorUtils {
         }
         // URL from the configuration was an absolute one. We return the same without any modification.
         return contextToBuildURL;
+    }
+
+    /**
+     * Get Account Lock Connector Configs.
+     *
+     * @param tenantDomain Tenant domain.
+     * @return AccountLockConnectorConfigs Account Lock Connector Configs.
+     * @throws AuthenticationFailedException Exception on authentication failure.
+     */
+    public static Property[] getAccountLockConnectorConfigs(String tenantDomain) throws
+            AuthenticationFailedException {
+
+        Property[] connectorConfigs;
+        try {
+            connectorConfigs = AuthenticatorDataHolder
+                    .getIdentityGovernanceService()
+                    .getConfiguration(
+                            new String[]{
+                                    LOGIN_FAIL_TIMEOUT_RATIO_PROPERTY,
+                                    AuthenticatorConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE,
+                                    FAILED_LOGIN_ATTEMPTS_PROPERTY,
+                                    ACCOUNT_UNLOCK_TIME_PROPERTY
+                            }, tenantDomain);
+        } catch (Exception e) {
+            throw new AuthenticationFailedException("Error occurred while retrieving account lock connector " +
+                    "configuration for tenant : " +  tenantDomain, e);
+        }
+        return connectorConfigs;
     }
 
     private static boolean isURLRelative(String contextFromConfig) throws URISyntaxException {


### PR DESCRIPTION
## Purpose
This PR adds the remainingNumberOfEmailOtpAttempts parameter in the response upon an invalid EmailOTP attempt when showAuthFailureReason is enabled

### Related Issue
- https://github.com/wso2/product-is/issues/21021

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.