### PR TITLE
Reset isRetrying property to properly handle the process Email OTP flow

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
@@ -94,6 +94,7 @@ import static org.wso2.carbon.identity.event.handler.notification.NotificationCo
 import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.FAILED_LOGIN_ATTEMPTS_PROPERTY;
 import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.CODE;
 import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.DISPLAY_CODE;
+import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.EMAIL_OTP_AUTHENTICATOR_NAME;
 import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.LogConstants.ActionIDs.INITIATE_EMAIL_OTP_REQUEST;
 import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.LogConstants.ActionIDs.PROCESS_AUTHENTICATION_RESPONSE;
 import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.LogConstants.EMAIL_OTP_SERVICE;
@@ -481,10 +482,16 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
     private AuthenticatorConstants.AuthenticationScenarios resolveScenario(HttpServletRequest request,
                                                                            AuthenticationContext context) {
 
+        // If the current authenticator is not EMAIL OTP, then set the flow to not retrying which could have been
+        // set from other authenticators and not cleared.
+        if (!EMAIL_OTP_AUTHENTICATOR_NAME.equals(context.getCurrentAuthenticator())) {
+            context.setRetrying(false);
+        }
+
         if (context.isLogoutRequest()) {
             return AuthenticatorConstants.AuthenticationScenarios.LOGOUT;
         } else if (!context.isRetrying() && StringUtils.isBlank(request.getParameter(CODE)) &&
-                StringUtils.isBlank(request.getParameter(AuthenticatorConstants.RESEND))) {
+                !Boolean.parseBoolean(request.getParameter(AuthenticatorConstants.RESEND))) {
             return AuthenticatorConstants.AuthenticationScenarios.INITIAL_OTP;
         } else if (context.isRetrying() &&
                 StringUtils.isNotBlank(request.getParameter(AuthenticatorConstants.RESEND)) &&


### PR DESCRIPTION
## Purpose
### Previous Behavior
When using MFA in the login flow, After successfully completing step 1 using basic authentication (username and password) and proceeding to step 2 (SMS OTP), entering a wrong OTP correctly triggers an error. However, upon entering the correct OTP for step 2, the system fails to send the OTP email required for step 3. Instead, an error message is displayed, halting the authentication flow.
[![Demo Video 1](https://img.youtube.com/vi/d-nX8i6R-jE/0.jpg)](https://youtu.be/d-nX8i6R-jE)

## Approach
- `context.isRetrying()` is set to `true` from previous failed authenticator.
- If the current authenticator set in the context is different than EMAIL OTP, then context.isRetrying() can be reset considering this is the first time the authentication flow is entering email OTP authenticator.

### Current Behavior
This PR will resolve the issue where the OTP email for step 3 was not sent after successfully completing step 2 (SMS OTP) with the correct code. The authentication flow now proceeds seamlessly, ensuring the user receives the OTP email for step 3 without any errors.
[![Demo Video 2](https://img.youtube.com/vi/1J02iju1oX4/0.jpg)](https://youtu.be/1J02iju1oX4)

## Related Issues
- https://github.com/wso2/product-is/issues/20282
