### PR TITLE
Resolve locale for JIT provisioned users

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -17,6 +17,8 @@
  */
 
 package org.wso2.carbon.identity.local.auth.emailotp.constant;
+
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 /**
  * Constants class.
@@ -51,6 +53,7 @@ public class AuthenticatorConstants {
     public static final String OTP_TOKEN = "otpToken";
     public static final String EMAIL_OTP_TEMPLATE_NAME = "EmailOTP";
     public static final String RESEND_EMAIL_OTP_TEMPLATE_NAME = "ResendEmailOTP";
+    public static final String LOCAL_CLAIM_VALUE = "locale";
 
     public static final String CODE_MISMATCH = "codeMismatch";
     public static final String OTP_EXPIRED = "isOTPExpired";
@@ -119,6 +122,7 @@ public class AuthenticatorConstants {
         public static final String OTP_BACKUP_CODES_CLAIM = "http://wso2.org/claims/identity/otpbackupcodes";
         public static final String EMAIL_OTP_FAILED_ATTEMPTS_CLAIM =
                 "http://wso2.org/claims/identity/failedEmailOtpAttempts";
+        public static final String LOCALE_CLAIM = IdentityUtil.getClaimUriLocale();
     }
 
     /**

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticatorTest.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.local.auth.emailotp;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -25,6 +26,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.extension.identity.helper.FederatedAuthenticatorUtil;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorFlowStatus;
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
 import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
@@ -41,17 +43,22 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatorParamMetadata;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.JustInTimeProvisioningConfig;
 import org.wso2.carbon.identity.captcha.internal.CaptchaDataHolder;
 import org.wso2.carbon.identity.captcha.util.CaptchaUtil;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants;
 import org.wso2.carbon.identity.local.auth.emailotp.internal.AuthenticatorDataHolder;
 import org.wso2.carbon.identity.local.auth.emailotp.util.AuthenticatorUtils;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
+import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.common.User;
@@ -73,10 +80,19 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.EMAIL_ADDRESS_CLAIM;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.USERNAME_CLAIM;
+import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.Claims.LOCALE_CLAIM;
 
+/**
+ * Class containing the test cases for EmailOTPAuthenticatorTest class.
+ */
 public class EmailOTPAuthenticatorTest {
 
     private EmailOTPAuthenticator emailOTPAuthenticator;
@@ -85,18 +101,8 @@ public class EmailOTPAuthenticatorTest {
     private AuthenticationContext context;
     private ConfigurationFacade configurationFacade;
     private MultiAttributeLoginService multiAttributeLoginService;
-    private MockedStatic<ConfigurationFacade> staticConfigurationFacade;
-    private MockedStatic<FrameworkUtils> frameworkUtils;
-    private MockedStatic<IdentityTenantUtil> identityTenantUtil;
     private FileBasedConfigurationBuilder fileBasedConfigurationBuilder;
-    private MockedStatic<FileBasedConfigurationBuilder> staticFileBasedConfigurationBuilder;
     private FrameworkServiceDataHolder frameworkServiceDataHolder;
-    private MockedStatic<FrameworkServiceDataHolder> staticFrameworkServiceDataHolder;
-    private MockedStatic<AuthenticatorUtils> authenticatorUtils;
-    private MockedStatic<CaptchaDataHolder> staticCaptchaDataHolder;
-    private MockedStatic<CaptchaUtil> captchaUtil;
-    private MockedStatic<UserCoreUtil> userCoreUtil;
-    private MockedStatic<LoggerUtils> mockLoggerUtils;
     private RealmService realmService;
     private UserRealm userRealm;
     private AbstractUserStoreManager userStoreManager;
@@ -105,6 +111,19 @@ public class EmailOTPAuthenticatorTest {
     private IdentityGovernanceService identityGovernanceService;
     private CaptchaDataHolder captchaDataHolder;
     private AuthenticatedUser authenticatedUserFromContext;
+    private IdpManager idpManager;
+
+    private MockedStatic<ConfigurationFacade> staticConfigurationFacade;
+    private MockedStatic<FrameworkUtils> frameworkUtils;
+    private MockedStatic<IdentityTenantUtil> identityTenantUtil;
+    private MockedStatic<FederatedAuthenticatorUtil> federatedAuthenticatorUtil;
+    private MockedStatic<FileBasedConfigurationBuilder> staticFileBasedConfigurationBuilder;
+    private MockedStatic<FrameworkServiceDataHolder> staticFrameworkServiceDataHolder;
+    private MockedStatic<AuthenticatorUtils> authenticatorUtils;
+    private MockedStatic<CaptchaDataHolder> staticCaptchaDataHolder;
+    private MockedStatic<CaptchaUtil> captchaUtil;
+    private MockedStatic<UserCoreUtil> userCoreUtil;
+    private MockedStatic<LoggerUtils> mockLoggerUtils;
 
     private static final String USERNAME = "abc@gmail.com";
     private static final String EMAIL_ADDRESS = "abc@gmail.com";
@@ -113,6 +132,7 @@ public class EmailOTPAuthenticatorTest {
     private static final String USER_STORE_DOMAIN = "PRIMARY";
     private static final String DEFAULT_USER_STORE = "DEFAULT";
     private static final String DUMMY_LOGIN_PAGE_URL = "dummyLoginPageURL";
+    private static final String SAMPLE_LOCALE = "fr-FR";
 
     @BeforeMethod
     public void setUp() {
@@ -132,10 +152,12 @@ public class EmailOTPAuthenticatorTest {
         identityGovernanceService = mock(IdentityGovernanceService.class);
         captchaDataHolder = mock(CaptchaDataHolder.class);
         multiAttributeLoginService = mock(MultiAttributeLoginService.class);
+        idpManager = mock(IdpManager.class);
 
         staticConfigurationFacade = mockStatic(ConfigurationFacade.class);
         frameworkUtils = mockStatic(FrameworkUtils.class);
         identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+        federatedAuthenticatorUtil = mockStatic(FederatedAuthenticatorUtil.class);
         mockLoggerUtils = mockStatic(LoggerUtils.class);
         staticFileBasedConfigurationBuilder = mockStatic(FileBasedConfigurationBuilder.class);
         staticFrameworkServiceDataHolder = mockStatic(FrameworkServiceDataHolder.class);
@@ -164,13 +186,7 @@ public class EmailOTPAuthenticatorTest {
     public void testIsRetryingInOTPAuthenticators(String currentAuthenticator)
             throws AuthenticationFailedException, LogoutFailedException {
 
-        Map<String, String> parameters = new HashMap<>();
-        parameters.put("BlockedUserStoreDomains", "");
-
-        AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig();
-        authenticatorConfig.setParameterMap(parameters);
-        setStepConfigWithEmailOTPAuthenticator(authenticatorConfig, context);
-
+        setAuthenticatorConfig();
         when(httpServletRequest.getParameter(AuthenticatorConstants.RESEND)).thenReturn(String.valueOf(true));
         when(ConfigurationFacade.getInstance()).thenReturn(configurationFacade);
         when(configurationFacade.getAuthenticationEndpointURL()).thenReturn(DUMMY_LOGIN_PAGE_URL);
@@ -194,19 +210,13 @@ public class EmailOTPAuthenticatorTest {
     public void testProcessWithoutAuthenticatedUserAndValidUsernameEntered()
             throws Exception {
 
-        Map<String, String> parameters = new HashMap<>();
-        parameters.put("BlockedUserStoreDomains", "");
-
-        AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig();
-        authenticatorConfig.setParameterMap(parameters);
-        setStepConfigWithEmailOTPAuthenticator(authenticatorConfig, context);
-
+        AuthenticatorConfig authenticatorConfig = setAuthenticatorConfig();
         when(ConfigurationFacade.getInstance()).thenReturn(configurationFacade);
         when(configurationFacade.getAuthenticationEndpointURL()).thenReturn(DUMMY_LOGIN_PAGE_URL);
 
         AuthenticatorFlowStatus status = emailOTPAuthenticator.process(httpServletRequest, httpServletResponse,
                 context);
-        Assert.assertEquals(status, AuthenticatorFlowStatus.INCOMPLETE);
+        assertEquals(status, AuthenticatorFlowStatus.INCOMPLETE);
         Assert.assertTrue(((boolean) context.getProperty(
                 AuthenticatorConstants.IS_IDF_INITIATED_FROM_AUTHENTICATOR)));
 
@@ -221,12 +231,7 @@ public class EmailOTPAuthenticatorTest {
         claimMap.put(EMAIL_ADDRESS_CLAIM, EMAIL_ADDRESS);
 
         context.setTenantDomain(TENANT_DOMAIN);
-
-        AuthenticatorDataHolder.setRealmService(realmService);
-        AuthenticatorDataHolder.setIdentityEventService(identityEventService);
-        AuthenticatorDataHolder.setClaimMetadataManagementService(claimMetadataManagementService);
-        AuthenticatorDataHolder.setIdentityEventService(identityEventService);
-        AuthenticatorDataHolder.setIdentityGovernanceService(identityGovernanceService);
+        configureAuthenticatorDataHolder();
 
         when(FrameworkUtils.preprocessUsername(USERNAME, context)).thenReturn(USERNAME + "@" + TENANT_DOMAIN);
         when(FileBasedConfigurationBuilder.getInstance()).thenReturn(fileBasedConfigurationBuilder);
@@ -244,7 +249,7 @@ public class EmailOTPAuthenticatorTest {
         userCoreUtil.when(UserCoreUtil::getDomainFromThreadLocal).thenReturn(DEFAULT_USER_STORE);
         mockMultiAttributeLoginService();
         status = emailOTPAuthenticator.process(httpServletRequest, httpServletResponse, context);
-        Assert.assertEquals(status, AuthenticatorFlowStatus.INCOMPLETE);
+        assertEquals(status, AuthenticatorFlowStatus.INCOMPLETE);
         Assert.assertTrue((Boolean.parseBoolean(String.valueOf(context.getProperty(
                 AuthenticatorConstants.IS_REDIRECT_TO_EMAIL_OTP)))));
     }
@@ -254,12 +259,7 @@ public class EmailOTPAuthenticatorTest {
     public void testProcessWithoutAuthenticatedUserAndInvalidUsernameEntered()
             throws Exception {
 
-        Map<String, String> parameters = new HashMap<>();
-        parameters.put("BlockedUserStoreDomains", "");
-
-        AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig();
-        authenticatorConfig.setParameterMap(parameters);
-        setStepConfigWithEmailOTPAuthenticator(authenticatorConfig, context);
+        AuthenticatorConfig authenticatorConfig = setAuthenticatorConfig();
 
         Map<String, String> claimMap = new HashMap<>();
         claimMap.put(EMAIL_ADDRESS_CLAIM, EMAIL_ADDRESS);
@@ -286,7 +286,7 @@ public class EmailOTPAuthenticatorTest {
 
         AuthenticatorFlowStatus status = emailOTPAuthenticator.process(httpServletRequest, httpServletResponse,
                 context);
-        Assert.assertEquals(status, AuthenticatorFlowStatus.INCOMPLETE);
+        assertEquals(status, AuthenticatorFlowStatus.INCOMPLETE);
         Assert.assertTrue((Boolean.parseBoolean(String.valueOf(context.getProperty(
                 AuthenticatorConstants.IS_REDIRECT_TO_EMAIL_OTP)))));
     }
@@ -327,21 +327,6 @@ public class EmailOTPAuthenticatorTest {
         when(multiAttributeLoginService.isEnabled(anyString())).thenReturn(false);
     }
 
-    @AfterMethod
-    public void cleanUp() {
-
-        staticConfigurationFacade.close();
-        frameworkUtils.close();
-        identityTenantUtil.close();
-        staticFileBasedConfigurationBuilder.close();
-        staticFrameworkServiceDataHolder.close();
-        authenticatorUtils.close();
-        staticCaptchaDataHolder.close();
-        captchaUtil.close();
-        userCoreUtil.close();
-        mockLoggerUtils.close();
-    }
-
     @Test
     public void testIsAPIBasedAuthenticationSupported() {
 
@@ -362,26 +347,132 @@ public class EmailOTPAuthenticatorTest {
                 0, Boolean.FALSE, AuthenticatorConstants.USERNAME_PARAM);
         authenticatorParamMetadataList.add(usernameMetadata);
 
-        Assert.assertEquals(authenticatorDataObj.getName(), AuthenticatorConstants.EMAIL_OTP_AUTHENTICATOR_NAME);
-        Assert.assertEquals(authenticatorDataObj.getDisplayName(),
+        assertEquals(authenticatorDataObj.getName(), AuthenticatorConstants.EMAIL_OTP_AUTHENTICATOR_NAME);
+        assertEquals(authenticatorDataObj.getDisplayName(),
                 AuthenticatorConstants.EMAIL_OTP_AUTHENTICATOR_FRIENDLY_NAME,
                 "Authenticator display name should match.");
-        Assert.assertEquals(authenticatorDataObj.getAuthParams().size(), authenticatorParamMetadataList.size(),
+        assertEquals(authenticatorDataObj.getAuthParams().size(), authenticatorParamMetadataList.size(),
                 "Size of lists should be equal.");
-        Assert.assertEquals(authenticatorDataObj.getPromptType(),
+        assertEquals(authenticatorDataObj.getPromptType(),
                 FrameworkConstants.AuthenticatorPromptType.USER_PROMPT);
-        Assert.assertEquals(authenticatorDataObj.getRequiredParams().size(),
+        assertEquals(authenticatorDataObj.getRequiredParams().size(),
                 1);
         for (int i = 0; i < authenticatorParamMetadataList.size(); i++) {
             AuthenticatorParamMetadata expectedParam = authenticatorParamMetadataList.get(i);
             AuthenticatorParamMetadata actualParam = authenticatorDataObj.getAuthParams().get(i);
 
-            Assert.assertEquals(actualParam.getName(), expectedParam.getName(), "Parameter name should match.");
-            Assert.assertEquals(actualParam.getType(), expectedParam.getType(), "Parameter type should match.");
-            Assert.assertEquals(actualParam.getParamOrder(), expectedParam.getParamOrder(),
+            assertEquals(actualParam.getName(), expectedParam.getName(), "Parameter name should match.");
+            assertEquals(actualParam.getType(), expectedParam.getType(), "Parameter type should match.");
+            assertEquals(actualParam.getParamOrder(), expectedParam.getParamOrder(),
                     "Parameter order should match.");
-            Assert.assertEquals(actualParam.isConfidential(), expectedParam.isConfidential(),
+            assertEquals(actualParam.isConfidential(), expectedParam.isConfidential(),
                     "Parameter mandatory status should match.");
         }
+    }
+
+    @DataProvider(name = "testSetAssociatedLocaleDataProvider")
+    public Object[][] testSetAssociatedLocaleDataProvider() {
+
+        return new Object[][] {
+                { true },   // For provisioned users with Locale changed in myaccount.
+                { false }   // For provisioned users without associated locale.
+        };
+    }
+
+    @Test(dataProvider = "testSetAssociatedLocaleDataProvider")
+    public void testSetAssociatedLocaleForProvisionedUsers(boolean hasAssociatedLocale) throws Exception {
+
+        Map<String, String> claimMap = new HashMap<>();
+        claimMap.put(EMAIL_ADDRESS_CLAIM, EMAIL_ADDRESS);
+        if (hasAssociatedLocale) {
+            claimMap.put(LOCALE_CLAIM, SAMPLE_LOCALE);
+        }
+        setAuthenticatorConfig();
+        configureAuthenticatedUser();
+        configureAuthenticatorDataHolder();
+        configureIdentityProvider();
+
+        IdentityProvider identityProvider = new IdentityProvider();
+        JustInTimeProvisioningConfig justInTimeProvisioningConfig = new JustInTimeProvisioningConfig();
+        justInTimeProvisioningConfig.setProvisioningUserStore(USER_STORE_DOMAIN);
+        identityProvider.setJustInTimeProvisioningConfig(justInTimeProvisioningConfig);
+        when(idpManager.getIdPByName(any(), any())).thenReturn(identityProvider);
+
+        when(FederatedAuthenticatorUtil.getLoggedInFederatedUser(any())).thenReturn(USERNAME);
+        when(FederatedAuthenticatorUtil.getLocalUsernameAssociatedWithFederatedUser(any(), any())).thenReturn(USERNAME);
+        when(realmService.getTenantUserRealm(TENANT_ID)).thenReturn(userRealm);
+        when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
+        when(userStoreManager.getUserClaimValues(any(), any(), any())).thenReturn(claimMap);
+        when(FileBasedConfigurationBuilder.getInstance()).thenReturn(fileBasedConfigurationBuilder);
+        when(CaptchaDataHolder.getInstance()).thenReturn(captchaDataHolder);
+
+        emailOTPAuthenticator.process(httpServletRequest, httpServletResponse, context);
+
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(identityEventService, times(2)).handleEvent(eventCaptor.capture());
+        Event capturedEvent = eventCaptor.getValue();
+
+        Map<String, Object> properties = capturedEvent.getEventProperties();
+        if (hasAssociatedLocale) {
+            assertNotNull(properties.get(AuthenticatorConstants.LOCAL_CLAIM_VALUE));
+        } else {
+            assertNull(properties.get(AuthenticatorConstants.LOCAL_CLAIM_VALUE));
+        }
+    }
+
+    private AuthenticatorConfig setAuthenticatorConfig() {
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("BlockedUserStoreDomains", "");
+
+        AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig();
+        authenticatorConfig.setParameterMap(parameters);
+        setStepConfigWithEmailOTPAuthenticator(authenticatorConfig, context);
+
+        return  authenticatorConfig;
+    }
+
+    private void configureAuthenticatorDataHolder() {
+
+        AuthenticatorDataHolder.setRealmService(realmService);
+        AuthenticatorDataHolder.setIdentityEventService(identityEventService);
+        AuthenticatorDataHolder.setClaimMetadataManagementService(claimMetadataManagementService);
+        AuthenticatorDataHolder.setIdentityGovernanceService(identityGovernanceService);
+        AuthenticatorDataHolder.setIdpManager(idpManager);
+    }
+
+    private void configureAuthenticatedUser() {
+
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setUserStoreDomain(USER_STORE_DOMAIN);
+        authenticatedUser.setUserName(USERNAME);
+        authenticatedUser.setTenantDomain(TENANT_DOMAIN);
+        authenticatedUser.setFederatedUser(true);
+        context.setSubject(authenticatedUser);
+    }
+
+    private void configureIdentityProvider() throws IdentityProviderManagementException {
+
+        IdentityProvider identityProvider = new IdentityProvider();
+        JustInTimeProvisioningConfig justInTimeProvisioningConfig = new JustInTimeProvisioningConfig();
+        justInTimeProvisioningConfig.setProvisioningUserStore(USER_STORE_DOMAIN);
+        identityProvider.setJustInTimeProvisioningConfig(justInTimeProvisioningConfig);
+        when(idpManager.getIdPByName(any(), any())).thenReturn(identityProvider);
+    }
+
+    @AfterMethod
+    public void cleanUp() {
+
+        staticConfigurationFacade.close();
+        frameworkUtils.close();
+        identityTenantUtil.close();
+        federatedAuthenticatorUtil.close();
+        staticFileBasedConfigurationBuilder.close();
+        staticFrameworkServiceDataHolder.close();
+        authenticatorUtils.close();
+        staticCaptchaDataHolder.close();
+        captchaUtil.close();
+        userCoreUtil.close();
+        mockLoggerUtils.close();
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

Fixes: https://github.com/wso2/product-is/issues/20606

For JIT-provisioned federated users, the locale is set in the event properties.

### When should this PR be merged

With the following PR:

- https://github.com/wso2-extensions/identity-event-handler-notification/pull/307

### Approach

The priority is set accordingly:

**Locale set in the event properties > Locale from mapped IDP federated claims > Default**

**Scenarios**
- For JIT provisioned federated users (With associated user locale - which means they changed it in the myaccount): --> **Locale set in the event properties** 
- For JIT provisioned federated users (Without associated user locale): --> **Locale from IDP federated claims** 
- For non-JIT provisioned federated users:  --> **Locale from IDP federated claims** 
- For non federated users:  --> **Locale from user claims** 