### PR TITLE
Add emailOTP executor

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/pom.xml
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/pom.xml
@@ -97,6 +97,10 @@
             <artifactId>org.wso2.carbon.identity.captcha</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.user.registration.engine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>
@@ -151,6 +155,12 @@
                             org.wso2.carbon.identity.captcha.*; version="${identity.governance.imp.pkg.version.range}",
                             javax.servlet.*; version="${imp.pkg.version.javax.servlet}",
                             org.owasp.encoder; version="${encoder.wso2.import.version.range}",
+                            org.wso2.carbon.identity.user.registration.engine.exception;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.user.registration.engine.graph;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.user.registration.engine.model;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/CommonUtils.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/CommonUtils.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.local.auth.emailotp;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
+import org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants;
+import org.wso2.carbon.identity.local.auth.emailotp.exception.EmailOtpAuthenticatorServerException;
+import org.wso2.carbon.identity.local.auth.emailotp.internal.AuthenticatorDataHolder;
+import org.wso2.carbon.identity.local.auth.emailotp.util.AuthenticatorUtils;
+
+import java.security.SecureRandom;
+
+/**
+ * Common utility functions for Email OTP Authenticator and Email OTP Executor.
+ */
+public class CommonUtils {
+
+    private static final Log LOG = LogFactory.getLog(CommonUtils.class);
+
+    private CommonUtils() {
+
+    }
+
+    /**
+     * Generate OTP.
+     *
+     * @param tenantDomain Tenant domain.
+     * @return Generated OTP.
+     * @throws EmailOtpAuthenticatorServerException Email OTP Authenticator Server Exception.
+     */
+    protected static String generateOTP(String tenantDomain) throws EmailOtpAuthenticatorServerException {
+
+        String charSet = getOTPCharset(tenantDomain);
+        int otpLength = getOTPLength(tenantDomain);
+
+        char[] chars = charSet.toCharArray();
+        SecureRandom rnd = new SecureRandom();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < otpLength; i++) {
+            sb.append(chars[rnd.nextInt(chars.length)]);
+        }
+        return sb.toString();
+    }
+
+    private static int getOTPLength(String tenantDomain) throws EmailOtpAuthenticatorServerException {
+
+        int otpLength = AuthenticatorConstants.DEFAULT_OTP_LENGTH;
+        String configuredOTPLength = AuthenticatorUtils.getEmailAuthenticatorConfig(
+                AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_LENGTH, tenantDomain);
+        if (NumberUtils.isNumber(configuredOTPLength)) {
+            otpLength = Integer.parseInt(configuredOTPLength);
+        }
+        return otpLength;
+    }
+
+    private static String getOTPCharset(String tenantDomain) throws EmailOtpAuthenticatorServerException {
+
+        boolean useAlphanumericChars = Boolean.parseBoolean(
+                AuthenticatorUtils.getEmailAuthenticatorConfig(
+                        AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_USE_ALPHANUMERIC_CHARS, tenantDomain));
+        if (useAlphanumericChars) {
+            return AuthenticatorConstants.EMAIL_OTP_UPPER_CASE_ALPHABET_CHAR_SET +
+                    AuthenticatorConstants.EMAIL_OTP_NUMERIC_CHAR_SET;
+        }
+        return AuthenticatorConstants.EMAIL_OTP_NUMERIC_CHAR_SET;
+    }
+
+    /**
+     * Get the email masking pattern.
+     *
+     * @param tenantDomain Tenant domain.
+     * @return Email masking pattern.
+     * @throws ClaimMetadataException Claim Metadata Exception.
+     */
+    protected static String getEmailMaskingPattern(String tenantDomain) throws ClaimMetadataException {
+
+        String regex = AuthenticatorDataHolder.getClaimMetadataManagementService().
+                getMaskingRegexForLocalClaim(AuthenticatorConstants.Claims.EMAIL_CLAIM, tenantDomain);
+        if (StringUtils.isNotBlank(regex)) {
+            return regex;
+        }
+        return AuthenticatorConstants.DEFAULT_EMAIL_MASKING_REGEX;
+    }
+
+    /**
+     * Get the OTP validity period.
+     *
+     * @param tenantDomain Tenant domain.
+     * @return OTP validity period.
+     * @throws EmailOtpAuthenticatorServerException Email OTP Authenticator Server Exception.
+     */
+    protected static long getOtpValidityPeriod(String tenantDomain)
+            throws EmailOtpAuthenticatorServerException {
+
+        String value = AuthenticatorUtils.getEmailAuthenticatorConfig(
+                AuthenticatorConstants.ConnectorConfig.OTP_EXPIRY_TIME, tenantDomain);
+        if (StringUtils.isBlank(value)) {
+            return AuthenticatorConstants.DEFAULT_EMAIL_OTP_VALIDITY_IN_MILLIS;
+        }
+        long validityTime;
+        try {
+            validityTime = Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            LOG.error(String.format("Email OTP validity period value: %s configured in tenant : %s is not a " +
+                            "number. Therefore, default validity period: %s (milli-seconds) will be used", value,
+                    tenantDomain, AuthenticatorConstants.DEFAULT_EMAIL_OTP_VALIDITY_IN_MILLIS));
+            return AuthenticatorConstants.DEFAULT_EMAIL_OTP_VALIDITY_IN_MILLIS;
+        }
+        // We don't need to send tokens with infinite validity.
+        if (validityTime < 0) {
+            LOG.error(String.format("Email OTP validity period value: %s configured in tenant : %s cannot be a " +
+                    "negative number. Therefore, default validity period: %s (milli-seconds) will " +
+                    "be used", value, tenantDomain, AuthenticatorConstants.DEFAULT_EMAIL_OTP_VALIDITY_IN_MILLIS));
+            return AuthenticatorConstants.DEFAULT_EMAIL_OTP_VALIDITY_IN_MILLIS;
+        }
+        // Converting to milliseconds since the config is provided in seconds.
+        return validityTime * 1000;
+    }
+}

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPExecutor.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPExecutor.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.local.auth.emailotp;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants;
+import org.wso2.carbon.identity.local.auth.emailotp.constant.ExecutorConstants;
+import org.wso2.carbon.identity.local.auth.emailotp.exception.EmailOtpAuthenticatorServerException;
+import org.wso2.carbon.identity.user.registration.engine.Constants;
+import org.wso2.carbon.identity.user.registration.engine.exception.RegistrationEngineException;
+import org.wso2.carbon.identity.user.registration.engine.exception.RegistrationEngineServerException;
+import org.wso2.carbon.identity.user.registration.engine.graph.Executor;
+import org.wso2.carbon.identity.user.registration.engine.model.ExecutorResponse;
+import org.wso2.carbon.identity.user.registration.engine.model.RegistrationContext;
+import org.wso2.carbon.utils.DiagnosticLog;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.EMAIL_ADDRESS_CLAIM;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.USERNAME_CLAIM;
+import static org.wso2.carbon.identity.event.handler.notification.NotificationConstants.ARBITRARY_SEND_TO;
+import static org.wso2.carbon.identity.event.handler.notification.NotificationConstants.EmailNotification.EMAIL_TEMPLATE_TYPE;
+import static org.wso2.carbon.identity.local.auth.emailotp.CommonUtils.generateOTP;
+import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.CODE;
+import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.LogConstants.ActionIDs.PROCESS_AUTHENTICATION_RESPONSE;
+import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.LogConstants.EMAIL_OTP_SERVICE;
+import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.RESEND;
+import static org.wso2.carbon.identity.local.auth.emailotp.util.ExecutorUtils.triggerEvent;
+import static org.wso2.carbon.identity.user.registration.engine.Constants.ExecutorStatus.STATUS_USER_INPUT_REQUIRED;
+
+/**
+ * Email OTP Executor.
+ */
+public class EmailOTPExecutor implements Executor {
+
+    @Override
+    public String getName() {
+
+        return ExecutorConstants.EMAIL_OTP_EXECUTOR_NAME;
+    }
+
+    @Override
+    public ExecutorResponse execute(RegistrationContext registrationContext) throws RegistrationEngineException {
+
+        ExecutorResponse executorResponse = new ExecutorResponse();
+        Map<String, Object> contextProperties = new HashMap<>();
+        executorResponse.setContextProperty(contextProperties);
+        handleRetryCount(registrationContext, executorResponse);
+
+        // Null OTP indicates the initial node execution. Therefore, OTP should be requested from the user.
+        // Further, the executor should trigger the email sending logic.
+        if (isInitiateRequest(registrationContext)) {
+            initiateEmailOTPRegistration(registrationContext, executorResponse);
+        } else {
+            processEmailOTPRegistration(registrationContext, executorResponse);
+        }
+        handleRetry(registrationContext, executorResponse);
+        return executorResponse;
+    }
+
+    @Override
+    public List<String> getInitiationData() {
+
+        List<String> initiationData = new ArrayList<>();
+        initiationData.add(EMAIL_ADDRESS_CLAIM);
+        initiationData.add(USERNAME_CLAIM);
+        return initiationData;
+    }
+
+    private boolean isInitiateRequest(RegistrationContext registrationContext) {
+
+        return registrationContext.getUserInputData().get(ExecutorConstants.OTP) == null;
+    }
+
+    private void handleRetryCount(RegistrationContext registrationContext, ExecutorResponse executorResponse) {
+
+        // To maintain the max retry attempts, the executor should maintain a counter in the context properties.
+        if (registrationContext.getProperty(ExecutorConstants.EMAIL_OTP_RETRY_COUNT) != null) {
+
+            int retryCount = (int) registrationContext.getProperty(ExecutorConstants.EMAIL_OTP_RETRY_COUNT);
+            // TODO: Configurable max retry count.
+            if (retryCount >= 3) {
+                executorResponse.setResult(Constants.ExecutorStatus.STATUS_ERROR);
+            }
+            executorResponse.getContextProperties().put(ExecutorConstants.EMAIL_OTP_RETRY_COUNT, retryCount + 1);
+        }
+    }
+
+    private void initiateEmailOTPRegistration(RegistrationContext context, ExecutorResponse executorResponse) {
+
+        executorResponse.setResult(STATUS_USER_INPUT_REQUIRED);
+        List<String> requiredData = new ArrayList<>();
+        requiredData.add(ExecutorConstants.OTP);
+        sendEmailOTP(AuthenticatorConstants.AuthenticationScenarios.INITIAL_OTP, context,
+                executorResponse.getContextProperties());
+        executorResponse.setRequiredData(requiredData);
+    }
+
+    private void processEmailOTPRegistration(RegistrationContext registrationContext,
+                                             ExecutorResponse executorResponse) throws RegistrationEngineException {
+        try {
+            if (LoggerUtils.isDiagnosticLogsEnabled()) {
+                DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                        EMAIL_OTP_SERVICE, PROCESS_AUTHENTICATION_RESPONSE);
+                diagnosticLogBuilder.resultMessage("Processing email otp verification response.")
+                        .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                        .resultStatus(DiagnosticLog.ResultStatus.SUCCESS);
+                LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+            }
+            // OTP is provided by the user. Therefore, the executor should validate the OTP.
+            // If the OTP is valid, the executor should return the success status.
+            // If the OTP is invalid, the executor should return an error status.
+            // The executor should maintain the OTP in the context properties to validate the OTP.
+            String otp = registrationContext.getUserInputData().get(ExecutorConstants.OTP);
+            if (StringUtils.isBlank(otp)) {
+                executorResponse.setResult(Constants.ExecutorStatus.STATUS_RETRY);
+            }
+            String contextOtp = (String) registrationContext.getProperty(ExecutorConstants.OTP);
+            if (contextOtp == null) {
+                executorResponse.setResult(Constants.ExecutorStatus.STATUS_ERROR);
+                executorResponse.setErrorMessage("OTP is not generated.");
+                return;
+            }
+            boolean isOtpExpired = isOtpExpired(registrationContext.getTenantDomain(), registrationContext);
+            if (otp.equals(contextOtp)) {
+                if (isOtpExpired) {
+                    executorResponse.setResult(Constants.ExecutorStatus.STATUS_RETRY);
+                    registrationContext.setProperty(ExecutorConstants.OTP_EXPIRED, true);
+                } else {
+                    executorResponse.setResult(Constants.ExecutorStatus.STATUS_COMPLETE);
+                    executorResponse.getContextProperties().put(ExecutorConstants.OTP_EXPIRED, false);
+                    executorResponse.getContextProperties().put(ExecutorConstants.OTP_GENERATED_TIME,
+                            StringUtils.EMPTY);
+                    executorResponse.getContextProperties().put(ExecutorConstants.OTP, StringUtils.EMPTY);
+                }
+            } else {
+                executorResponse.setResult(Constants.ExecutorStatus.STATUS_RETRY);
+            }
+        } catch (EmailOtpAuthenticatorServerException e) {
+            if (LoggerUtils.isDiagnosticLogsEnabled()) {
+                DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                        EMAIL_OTP_SERVICE, PROCESS_AUTHENTICATION_RESPONSE);
+                diagnosticLogBuilder.resultMessage("Error occurred while processing email otp authentication response.")
+                        .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                        .resultStatus(DiagnosticLog.ResultStatus.FAILED);
+                LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+            }
+            throw handleAuthErrorScenario(AuthenticatorConstants.ErrorMessages.ERROR_CODE_ERROR_GETTING_CONFIG, e,
+                    registrationContext);
+        }
+    }
+
+    /**
+     * Checks whether otp is Expired or not.
+     *
+     * @param tenantDomain Tenant domain.
+     * @param context      Authentication Context.
+     */
+    private boolean isOtpExpired(String tenantDomain, RegistrationContext context)
+            throws RegistrationEngineException, EmailOtpAuthenticatorServerException {
+
+        if (context.getProperty(AuthenticatorConstants.OTP_GENERATED_TIME) == null) {
+            throw handleAuthErrorScenario(AuthenticatorConstants.ErrorMessages.ERROR_CODE_EMPTY_GENERATED_TIME, null,
+                    context);
+        }
+        long generatedTime = (long) context.getProperty(AuthenticatorConstants.OTP_GENERATED_TIME);
+        long expireTime = CommonUtils.getOtpValidityPeriod(tenantDomain);
+        return System.currentTimeMillis() >= generatedTime + expireTime;
+    }
+
+    private void sendEmailOTP(AuthenticatorConstants.AuthenticationScenarios scenario, RegistrationContext context,
+                              Map<String, Object> contextProperties) {
+
+        try {
+            String tenantDomain = context.getTenantDomain();
+            String email = String.valueOf(context.getUserInputData().get(EMAIL_ADDRESS_CLAIM));
+            String username = String.valueOf(context.getUserInputData().get(USERNAME_CLAIM));
+
+            // Generate OTP.
+            String otp = generateOTP(tenantDomain);
+            contextProperties.put(ExecutorConstants.OTP, otp);
+            contextProperties.put(ExecutorConstants.OTP_GENERATED_TIME, System.currentTimeMillis());
+            contextProperties.put(ExecutorConstants.OTP_EXPIRED, false);
+            publishPostEmailOTPGeneratedEvent(context);
+
+            Map<String, Object> metaProperties = new HashMap<>();
+            metaProperties.put(CODE, otp);
+            metaProperties.put(EMAIL_TEMPLATE_TYPE, ExecutorConstants.EMAIL_OTP_VERIFY_TEMPLATE);
+            metaProperties.put(ARBITRARY_SEND_TO, email);
+            metaProperties.put(ExecutorConstants.TENANT_DOMAIN, tenantDomain);
+            triggerEvent(IdentityEventConstants.Event.TRIGGER_NOTIFICATION, metaProperties);
+            if (LoggerUtils.isDiagnosticLogsEnabled()) {
+                DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                        EMAIL_OTP_SERVICE, AuthenticatorConstants.LogConstants.ActionIDs.SEND_EMAIL_OTP);
+                diagnosticLogBuilder.resultMessage("Email OTP sent successfully.")
+                        .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
+                        .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                        .inputParam(LogConstants.InputKeys.USER, LoggerUtils.isLogMaskingEnable ?
+                                LoggerUtils.getMaskedContent(username) : username)
+                        .inputParam("scenario", scenario.name());
+                LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+            }
+        } catch (EmailOtpAuthenticatorServerException | IdentityEventException e) {
+            if (LoggerUtils.isDiagnosticLogsEnabled()) {
+                DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                        EMAIL_OTP_SERVICE, AuthenticatorConstants.LogConstants.ActionIDs.SEND_EMAIL_OTP);
+                diagnosticLogBuilder.resultMessage("Error occurred while sending email OTP.")
+                        .resultStatus(DiagnosticLog.ResultStatus.FAILED)
+                        .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                        .inputParam("scenario", scenario.name());
+                LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+            }
+
+        }
+    }
+
+    private void handleRetry(RegistrationContext context, ExecutorResponse executorResponse) {
+
+        if (executorResponse.getResult().equals(Constants.ExecutorStatus.STATUS_RETRY)) {
+            sendEmailOTP(AuthenticatorConstants.AuthenticationScenarios.RESEND_OTP, context,
+                    executorResponse.getContextProperties());
+            executorResponse.getContextProperties().put(AuthenticatorConstants.RESEND, true);
+            executorResponse.setErrorMessage("Invalid OTP. Please try again.");
+        }
+    }
+
+    /**
+     * Trigger event after generating Email OTP.
+     *
+     * @param context Registration context.
+     */
+    private void publishPostEmailOTPGeneratedEvent(RegistrationContext context)
+            throws EmailOtpAuthenticatorServerException, IdentityEventException {
+
+        String tenantDomain = context.getTenantDomain();
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(IdentityEventConstants.EventProperty.CORRELATION_ID, context.getCorrelationId());
+        String resendCode = String.valueOf(context.getProperty(RESEND));
+        if (StringUtils.isNotBlank(resendCode)) {
+            eventProperties.put(IdentityEventConstants.EventProperty.RESEND_CODE, resendCode);
+        } else {
+            eventProperties.put(IdentityEventConstants.EventProperty.RESEND_CODE, false);
+        }
+        // Add OTP generated time and OTP expiry time to the event.
+        Object otpGeneratedTimeProperty = context.getProperty(AuthenticatorConstants.OTP_GENERATED_TIME);
+        if (otpGeneratedTimeProperty != null) {
+            long otpGeneratedTime = (long) otpGeneratedTimeProperty;
+            eventProperties.put(IdentityEventConstants.EventProperty.OTP_GENERATED_TIME, otpGeneratedTime);
+
+            // Calculate OTP expiry time.
+            long expiryTime = otpGeneratedTime + CommonUtils.getOtpValidityPeriod(tenantDomain);
+            eventProperties.put(IdentityEventConstants.EventProperty.OTP_EXPIRY_TIME, expiryTime);
+        }
+        triggerEvent(IdentityEventConstants.Event.POST_GENERATE_EMAIL_OTP, eventProperties);
+    }
+
+    /**
+     * Handle the scenario by returning RegistrationEngineServerException which has the details of the error scenario.
+     *
+     * @param error     {@link AuthenticatorConstants.ErrorMessages} error message.
+     * @param throwable Throwable.
+     * @param data      Additional data related to the scenario.
+     * @return RegistrationEngineServerException.
+     */
+    @SuppressFBWarnings("FORMAT_STRING_MANIPULATION")
+    private RegistrationEngineServerException handleAuthErrorScenario(AuthenticatorConstants.ErrorMessages error,
+                                                                      Throwable throwable, RegistrationContext context,
+                                                                      Object... data) {
+
+        String message = error.getMessage();
+        if (data != null) {
+            message = String.format(message, data);
+        }
+        String errorCode = error.getCode();
+        return new RegistrationEngineServerException(errorCode, message, "Error occurred in the email OTP executor",
+                throwable);
+    }
+}

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/ExecutorConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/ExecutorConstants.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.local.auth.emailotp.constant;
+
+/**
+ * Constants for the executor.
+ */
+public class ExecutorConstants {
+
+    private ExecutorConstants() {
+
+    }
+
+    public static final String EMAIL_OTP_EXECUTOR_NAME = "EmailOTPExecutor";
+    public static final String OTP = "otp";
+    public static final String OTP_GENERATED_TIME = "tokenGeneratedTime";
+    public static final String OTP_EXPIRED = "isOTPExpired";
+    public static final String EMAIL_OTP_RETRY_COUNT = "emailOTPRetryCount";
+    public static final String USER_NAME = "username";
+    public static final String TENANT_DOMAIN = "tenantDomain";
+    public static final String EMAIL_OTP_VERIFY_TEMPLATE = "EmailOTPVerification";
+}

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/internal/AuthenticatorServiceComponent.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/internal/AuthenticatorServiceComponent.java
@@ -35,7 +35,9 @@ import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
 import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.identity.local.auth.emailotp.EmailOTPAuthenticator;
+import org.wso2.carbon.identity.local.auth.emailotp.EmailOTPExecutor;
 import org.wso2.carbon.identity.local.auth.emailotp.connector.EmailOTPAuthenticatorConfigImpl;
+import org.wso2.carbon.identity.user.registration.engine.graph.Executor;
 import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.user.core.service.RealmService;
 
@@ -59,6 +61,7 @@ public class AuthenticatorServiceComponent {
                     new EmailOTPAuthenticatorConfigImpl(), null);
             bundleContext.registerService(ApplicationAuthenticator.class.getName(),
                     new EmailOTPAuthenticator(), null);
+            bundleContext.registerService(Executor.class.getName(), new EmailOTPExecutor(), null);
             if (log.isDebugEnabled()) {
                 log.debug("Email OTP authenticator is activated");
             }

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/util/ExecutorUtils.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/util/ExecutorUtils.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.local.auth.emailotp.util;
+
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.handler.notification.NotificationConstants;
+import org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants;
+import org.wso2.carbon.identity.local.auth.emailotp.internal.AuthenticatorDataHolder;
+import org.wso2.carbon.utils.DiagnosticLog;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.wso2.carbon.identity.local.auth.emailotp.constant.ExecutorConstants.TENANT_DOMAIN;
+import static org.wso2.carbon.identity.local.auth.emailotp.constant.ExecutorConstants.USER_NAME;
+
+/**
+ * Utility class for executor operations.
+ */
+public class ExecutorUtils {
+
+    private ExecutorUtils() {
+
+    }
+
+    public static void triggerEvent(String eventName, Map<String, Object> metaProperties)
+            throws IdentityEventException {
+
+        String username = String.valueOf(metaProperties.remove(USER_NAME));
+        String tenantDomain = String.valueOf(metaProperties.remove(TENANT_DOMAIN));
+
+        // Event properties.
+        HashMap<String, Object> properties = new HashMap<>();
+        properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
+        properties.put(NotificationConstants.FLOW_TYPE, NotificationConstants.REGISTRATION_FLOW);
+
+        for (Map.Entry<String, Object> metaProperty : metaProperties.entrySet()) {
+            if (StringUtils.isNotBlank(metaProperty.getKey()) && metaProperty.getValue() != null) {
+                properties.put(metaProperty.getKey(), metaProperty.getValue());
+            }
+        }
+        Event identityMgtEvent = new Event(eventName, properties);
+        String receiver = (String) properties.get("send-to");
+        if (LoggerUtils.isDiagnosticLogsEnabled() && eventName.equals(IdentityEventConstants.Event
+                .TRIGGER_NOTIFICATION)) {
+            DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                    AuthenticatorConstants.LogConstants.EMAIL_OTP_SERVICE,
+                    AuthenticatorConstants.LogConstants.ActionIDs.SEND_EMAIL_OTP);
+            diagnosticLogBuilder
+                    .inputParam(LogConstants.InputKeys.USER, LoggerUtils.isLogMaskingEnable ?
+                            LoggerUtils.getMaskedContent(username) : username)
+                    .inputParam(LogConstants.InputKeys.TENANT_DOMAIN, tenantDomain)
+                    .inputParam(LogConstants.InputKeys.SERVICE_PROVIDER, properties.get("serviceProviderName"))
+                    .inputParam(AuthenticatorConstants.LogConstants.InputKeys.EMAIL_TO,
+                            LoggerUtils.isLogMaskingEnable ?
+                                    LoggerUtils.getMaskedContent(receiver) : receiver)
+                    .resultMessage("Email sending event will be triggered.")
+                    .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
+                    .logDetailLevel(DiagnosticLog.LogDetailLevel.INTERNAL_SYSTEM);
+            LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+        }
+        AuthenticatorDataHolder.getIdentityEventService().handleEvent(identityMgtEvent);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,11 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.user.registration.engine</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.governance</groupId>
                 <artifactId>org.wso2.carbon.identity.governance</artifactId>
                 <version>${carbon.identity.governance.version}</version>
@@ -311,11 +316,11 @@
         <encoder.wso2.import.version.range>[1.2.0, 2.0.0)</encoder.wso2.import.version.range>
 
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
-        <carbon.identity.framework.version>7.0.106</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.48</carbon.identity.framework.version>
         <carbon.identity.governance.version>1.8.40</carbon.identity.governance.version>
         <carbon.identity.handler.event.account.lock.version>1.8.2</carbon.identity.handler.event.account.lock.version>
         <carbon.extension.identity.helper.version>1.0.12</carbon.extension.identity.helper.version>
-        <carbon.identity.event.handler.notification.version>1.8.17</carbon.identity.event.handler.notification.version>
+        <carbon.identity.event.handler.notification.version>1.9.45</carbon.identity.event.handler.notification.version>
         <owasp.encoder.version>1.2.0.wso2v1</owasp.encoder.version>
         <mockito-inline.version>3.8.0</mockito-inline.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
         <encoder.wso2.import.version.range>[1.2.0, 2.0.0)</encoder.wso2.import.version.range>
 
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
-        <carbon.identity.framework.version>7.8.48</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.55</carbon.identity.framework.version>
         <carbon.identity.governance.version>1.8.40</carbon.identity.governance.version>
         <carbon.identity.handler.event.account.lock.version>1.8.2</carbon.identity.handler.event.account.lock.version>
         <carbon.extension.identity.helper.version>1.0.12</carbon.extension.identity.helper.version>


### PR DESCRIPTION
## Purpose

Onboard EmailOTPExecutor which will enable users to verify their email using an OTP flow.

## Issue

https://github.com/wso2/product-is/issues/23356

Depends on https://github.com/wso2-extensions/identity-event-handler-notification/pull/310