### PR TITLE
Unify OTP Parameter Handling in Email OTP Authenticator

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
@@ -49,6 +49,7 @@ public class AuthenticatorConstants {
 
     public static final String RESEND = "resendCode";
     public static final String CODE = "OTPCode";
+    public static final String CODE_LOWERCASE = "OTPcode";
     public static final String DISPLAY_CODE = "Code";
     public static final String OTP_TOKEN = "otpToken";
     public static final String EMAIL_OTP_TEMPLATE_NAME = "EmailOTP";


### PR DESCRIPTION
## Purpose 
Unify the parameter naming convention for OTP authentication in SMS OTP and Email OTP steps by allowing both "OTPcode" and "OTPCode" in the Email OTP authenticator. 

## Implementation

This PR introduces several changes to the `EmailOTPAuthenticator` to enhance the handling of OTP parameters. The key changes include the addition of a new OTP parameter, `CODE_LOWERCASE`, and the implementation of a method to manage this new parameter.

* Added a new constant `CODE_LOWERCASE` for the alternative OTP code parameter.
* Added the helper method `getCurrentCodeParam` to check for the presence of `CODE_LOWERCASE` when `CODE` is absent.

## Updated Behavior

https://github.com/user-attachments/assets/d447bcc3-9bca-4e0b-9de8-068001668b0b

## Related Issues
- https://github.com/wso2/product-is/issues/23268