### PR TITLE
Resend email OTP only when it is expired

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPExecutor.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPExecutor.java
@@ -258,8 +258,14 @@ public class EmailOTPExecutor implements Executor {
     private void handleRetry(RegistrationContext context, ExecutorResponse executorResponse) {
 
         if (executorResponse.getResult().equals(Constants.ExecutorStatus.STATUS_RETRY)) {
-            sendEmailOTP(AuthenticatorConstants.AuthenticationScenarios.RESEND_OTP, context,
-                    executorResponse);
+            Object isOTPExpiredObj = context.getProperty(ExecutorConstants.OTP_EXPIRED);
+            if (isOTPExpiredObj != null && (boolean) isOTPExpiredObj) {
+                sendEmailOTP(AuthenticatorConstants.AuthenticationScenarios.RESEND_OTP, context,
+                        executorResponse);
+                executorResponse.setResult(Constants.ExecutorStatus.STATUS_RETRY);
+                executorResponse.setErrorMessage("OTP expired. Please try again.");
+                return;
+            }
             executorResponse.getContextProperties().put(AuthenticatorConstants.RESEND, true);
             executorResponse.setErrorMessage("Invalid OTP. Please try again.");
         }


### PR DESCRIPTION
## Purpose

Improve the email OTP executor to only resend the OTP mail when the user tries with an expired OTP code. In other cases send a retry without triggering a resend.

## Issue

https://github.com/wso2/product-is/issues/23356