### PR TITLE
Fix OTP sending failure due to OTPCode set from SMS OTP Authenticator

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
@@ -497,7 +497,8 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
 
         if (context.isLogoutRequest()) {
             return AuthenticatorConstants.AuthenticationScenarios.LOGOUT;
-        } else if (!context.isRetrying() && StringUtils.isBlank(request.getParameter(getCurrentCodeParam(request))) &&
+        } else if (!EMAIL_OTP_AUTHENTICATOR_NAME.equals(context.getCurrentAuthenticator()) ||
+                !context.isRetrying() && StringUtils.isBlank(request.getParameter(getCurrentCodeParam(request))) &&
                 !Boolean.parseBoolean(request.getParameter(AuthenticatorConstants.RESEND))) {
             return AuthenticatorConstants.AuthenticationScenarios.INITIAL_OTP;
         } else if (context.isRetrying() &&

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
@@ -75,11 +75,15 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -93,6 +97,7 @@ import static org.wso2.carbon.identity.event.handler.notification.NotificationCo
 import static org.wso2.carbon.identity.event.handler.notification.NotificationConstants.EmailNotification.EMAIL_TEMPLATE_TYPE;
 import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.FAILED_LOGIN_ATTEMPTS_PROPERTY;
 import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.CODE;
+import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.CODE_LOWERCASE;
 import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.DISPLAY_CODE;
 import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.EMAIL_OTP_AUTHENTICATOR_NAME;
 import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.LogConstants.ActionIDs.INITIATE_EMAIL_OTP_REQUEST;
@@ -152,9 +157,10 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
         if (log.isDebugEnabled()) {
             log.debug("Inside EmailOTPAuthenticator canHandle method");
         }
+        String codeParam = getCurrentCodeParam(request);
         boolean canHandle = ((StringUtils.isNotBlank(request.getParameter(AuthenticatorConstants.RESEND))
-                && StringUtils.isBlank(request.getParameter(CODE)))
-                || StringUtils.isNotBlank(request.getParameter(CODE))
+                && StringUtils.isBlank(request.getParameter(codeParam)))
+                || StringUtils.isNotBlank(request.getParameter(codeParam))
                 || StringUtils.isNotBlank(request.getParameter(AuthenticatorConstants.USER_NAME)));
         if (canHandle && LoggerUtils.isDiagnosticLogsEnabled()) {
             DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
@@ -339,7 +345,8 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
         boolean isInitialFederationAttempt = StringUtils.isBlank(mappedLocalUsername);
         AuthenticatedUser authenticatingUser = resolveAuthenticatingUser(authenticatedUserFromContext,
                 mappedLocalUsername, applicationTenantDomain, isInitialFederationAttempt, context);
-        if (StringUtils.isBlank(request.getParameter(CODE))) {
+        String codeParam = getCurrentCodeParam(request);
+        if (StringUtils.isBlank(request.getParameter(codeParam))) {
             throw handleInvalidCredentialsScenario(AuthenticatorConstants.ErrorMessages.ERROR_CODE_EMPTY_OTP_CODE,
                     authenticatedUserFromContext.getUserName());
         }
@@ -348,7 +355,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                     authenticatedUserFromContext.getUserName());
         }
         boolean isSuccessfulAttempt =
-                isSuccessfulAuthAttempt(request.getParameter(CODE), applicationTenantDomain,
+                isSuccessfulAuthAttempt(request.getParameter(codeParam), applicationTenantDomain,
                         authenticatingUser, context);
         if (isSuccessfulAttempt) {
             if (!isInitialFederationAttempt && AuthenticatorUtils.isAccountLocked(authenticatingUser)) {
@@ -490,7 +497,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
 
         if (context.isLogoutRequest()) {
             return AuthenticatorConstants.AuthenticationScenarios.LOGOUT;
-        } else if (!context.isRetrying() && StringUtils.isBlank(request.getParameter(CODE)) &&
+        } else if (!context.isRetrying() && StringUtils.isBlank(request.getParameter(getCurrentCodeParam(request))) &&
                 !Boolean.parseBoolean(request.getParameter(AuthenticatorConstants.RESEND))) {
             return AuthenticatorConstants.AuthenticationScenarios.INITIAL_OTP;
         } else if (context.isRetrying() &&
@@ -865,19 +872,20 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
             throws AuthenticationFailedException {
 
         String tenantDomain = context.getTenantDomain();
+        String codeParam = getCurrentCodeParam(request);
 
         Map<String, Object> eventProperties = new HashMap<>();
         eventProperties.put(IdentityEventConstants.EventProperty.CORRELATION_ID, context.getCallerSessionKey());
         eventProperties.put(IdentityEventConstants.EventProperty.APPLICATION_NAME, context.getServiceProviderName());
         eventProperties.put(IdentityEventConstants.EventProperty.USER_INPUT_OTP, request.getParameter(
-                CODE));
+                codeParam));
         eventProperties.put(IdentityEventConstants.EventProperty.OTP_USED_TIME, System.currentTimeMillis());
 
         // Add otp status to the event properties.
         if (isAuthenticationPassed) {
             eventProperties.put(IdentityEventConstants.EventProperty.OTP_STATUS, AuthenticatorConstants.STATUS_SUCCESS);
             eventProperties.put(IdentityEventConstants.EventProperty.GENERATED_OTP, request.getParameter(
-                    CODE));
+                    codeParam));
         } else {
             if (isExpired) {
                 eventProperties.put(IdentityEventConstants.EventProperty.OTP_STATUS,
@@ -1814,6 +1822,26 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                     getAuthenticatedUserFromContext(context));
             throw new AuthenticationFailedException(errorMessage, e);
         }
+    }
+
+    /**
+     * Accept both "OTPcode" and "OTPCode" as valid parameters
+     * by checking for the presence of CODE_LOWERCASE when CODE is absent.
+     *
+     * @param request The HTTP servlet request containing the parameters.
+     * @return {@code CODE_LOWERCASE} if present and {@code CODE} is absent, otherwise {@code CODE}.
+     */
+    private String getCurrentCodeParam(HttpServletRequest request) {
+
+        Enumeration<String> parameterNames = request.getParameterNames();
+
+        // If parameterNames is null, return CODE to preserve the existing behavior where CODE is the default.
+        if (parameterNames == null) {
+            return CODE;
+        }
+
+        Set<String> requestParams = new HashSet<>(Collections.list(request.getParameterNames()));
+        return requestParams.contains(CODE_LOWERCASE) && !requestParams.contains(CODE) ? CODE_LOWERCASE : CODE;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
@@ -49,6 +49,7 @@ public class AuthenticatorConstants {
 
     public static final String RESEND = "resendCode";
     public static final String CODE = "OTPCode";
+    public static final String CODE_LOWERCASE = "OTPcode";
     public static final String DISPLAY_CODE = "Code";
     public static final String OTP_TOKEN = "otpToken";
     public static final String EMAIL_OTP_TEMPLATE_NAME = "EmailOTP";


### PR DESCRIPTION
### Purpose
- Resolve the scenario properly when there is residual data available from SMS OTP Authenticator
- Revert https://github.com/wso2-extensions/identity-local-auth-emailotp/pull/46

### Related Issue
- https://github.com/wso2/product-is/issues/23543