### PR TITLE
support for both OTPCode and OTPcode parameters

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
@@ -75,11 +75,15 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -93,6 +97,7 @@ import static org.wso2.carbon.identity.event.handler.notification.NotificationCo
 import static org.wso2.carbon.identity.event.handler.notification.NotificationConstants.EmailNotification.EMAIL_TEMPLATE_TYPE;
 import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.FAILED_LOGIN_ATTEMPTS_PROPERTY;
 import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.CODE;
+import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.CODE_LOWERCASE;
 import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.DISPLAY_CODE;
 import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.EMAIL_OTP_AUTHENTICATOR_NAME;
 import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.LogConstants.ActionIDs.INITIATE_EMAIL_OTP_REQUEST;
@@ -152,9 +157,10 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
         if (log.isDebugEnabled()) {
             log.debug("Inside EmailOTPAuthenticator canHandle method");
         }
+        String codeParam = getCurrentCodeParam(request);
         boolean canHandle = ((StringUtils.isNotBlank(request.getParameter(AuthenticatorConstants.RESEND))
-                && StringUtils.isBlank(request.getParameter(CODE)))
-                || StringUtils.isNotBlank(request.getParameter(CODE))
+                && StringUtils.isBlank(request.getParameter(codeParam)))
+                || StringUtils.isNotBlank(request.getParameter(codeParam))
                 || StringUtils.isNotBlank(request.getParameter(AuthenticatorConstants.USER_NAME)));
         if (canHandle && LoggerUtils.isDiagnosticLogsEnabled()) {
             DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
@@ -213,6 +219,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                 context.setProperty(AuthenticatorConstants.IS_IDF_INITIATED_FROM_AUTHENTICATOR, true);
                 return;
             }
+            context.removeProperty(AuthenticatorConstants.IS_IDF_INITIATED_FROM_AUTHENTICATOR);
 
             // When username is obtained through IDF page and the user is not yet set in the context.
             AuthenticatedUser authenticatedUser = resolveUser(request, context);
@@ -339,7 +346,8 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
         boolean isInitialFederationAttempt = StringUtils.isBlank(mappedLocalUsername);
         AuthenticatedUser authenticatingUser = resolveAuthenticatingUser(authenticatedUserFromContext,
                 mappedLocalUsername, applicationTenantDomain, isInitialFederationAttempt, context);
-        if (StringUtils.isBlank(request.getParameter(CODE))) {
+        String codeParam = getCurrentCodeParam(request);
+        if (StringUtils.isBlank(request.getParameter(codeParam))) {
             throw handleInvalidCredentialsScenario(AuthenticatorConstants.ErrorMessages.ERROR_CODE_EMPTY_OTP_CODE,
                     authenticatedUserFromContext.getUserName());
         }
@@ -348,7 +356,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                     authenticatedUserFromContext.getUserName());
         }
         boolean isSuccessfulAttempt =
-                isSuccessfulAuthAttempt(request.getParameter(CODE), applicationTenantDomain,
+                isSuccessfulAuthAttempt(request.getParameter(codeParam), applicationTenantDomain,
                         authenticatingUser, context);
         if (isSuccessfulAttempt) {
             if (!isInitialFederationAttempt && AuthenticatorUtils.isAccountLocked(authenticatingUser)) {
@@ -490,7 +498,8 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
 
         if (context.isLogoutRequest()) {
             return AuthenticatorConstants.AuthenticationScenarios.LOGOUT;
-        } else if (!context.isRetrying() && StringUtils.isBlank(request.getParameter(CODE)) &&
+        } else if (!EMAIL_OTP_AUTHENTICATOR_NAME.equals(context.getCurrentAuthenticator()) ||
+                !context.isRetrying() && StringUtils.isBlank(request.getParameter(getCurrentCodeParam(request))) &&
                 !Boolean.parseBoolean(request.getParameter(AuthenticatorConstants.RESEND))) {
             return AuthenticatorConstants.AuthenticationScenarios.INITIAL_OTP;
         } else if (context.isRetrying() &&
@@ -865,19 +874,20 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
             throws AuthenticationFailedException {
 
         String tenantDomain = context.getTenantDomain();
+        String codeParam = getCurrentCodeParam(request);
 
         Map<String, Object> eventProperties = new HashMap<>();
         eventProperties.put(IdentityEventConstants.EventProperty.CORRELATION_ID, context.getCallerSessionKey());
         eventProperties.put(IdentityEventConstants.EventProperty.APPLICATION_NAME, context.getServiceProviderName());
         eventProperties.put(IdentityEventConstants.EventProperty.USER_INPUT_OTP, request.getParameter(
-                CODE));
+                codeParam));
         eventProperties.put(IdentityEventConstants.EventProperty.OTP_USED_TIME, System.currentTimeMillis());
 
         // Add otp status to the event properties.
         if (isAuthenticationPassed) {
             eventProperties.put(IdentityEventConstants.EventProperty.OTP_STATUS, AuthenticatorConstants.STATUS_SUCCESS);
             eventProperties.put(IdentityEventConstants.EventProperty.GENERATED_OTP, request.getParameter(
-                    CODE));
+                    codeParam));
         } else {
             if (isExpired) {
                 eventProperties.put(IdentityEventConstants.EventProperty.OTP_STATUS,
@@ -1814,6 +1824,26 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                     getAuthenticatedUserFromContext(context));
             throw new AuthenticationFailedException(errorMessage, e);
         }
+    }
+
+    /**
+     * Accept both "OTPcode" and "OTPCode" as valid parameters
+     * by checking for the presence of CODE_LOWERCASE when CODE is absent.
+     *
+     * @param request The HTTP servlet request containing the parameters.
+     * @return {@code CODE_LOWERCASE} if present and {@code CODE} is absent, otherwise {@code CODE}.
+     */
+    private String getCurrentCodeParam(HttpServletRequest request) {
+
+        Enumeration<String> parameterNames = request.getParameterNames();
+
+        // If parameterNames is null, return CODE to preserve the existing behavior where CODE is the default.
+        if (parameterNames == null) {
+            return CODE;
+        }
+
+        Set<String> requestParams = new HashSet<>(Collections.list(request.getParameterNames()));
+        return requestParams.contains(CODE_LOWERCASE) && !requestParams.contains(CODE) ? CODE_LOWERCASE : CODE;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
@@ -49,6 +49,7 @@ public class AuthenticatorConstants {
 
     public static final String RESEND = "resendCode";
     public static final String CODE = "OTPCode";
+    public static final String CODE_LOWERCASE = "OTPcode";
     public static final String DISPLAY_CODE = "Code";
     public static final String OTP_TOKEN = "otpToken";
     public static final String EMAIL_OTP_TEMPLATE_NAME = "EmailOTP";

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticatorTest.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.InvalidCredentialsException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.LogoutFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
@@ -65,7 +66,10 @@ import org.wso2.carbon.user.core.common.User;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -89,6 +93,8 @@ import static org.testng.Assert.assertNull;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.EMAIL_ADDRESS_CLAIM;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.USERNAME_CLAIM;
 import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.Claims.LOCALE_CLAIM;
+import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.EMAIL_OTP_AUTHENTICATOR_NAME;
+import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.IS_IDF_INITIATED_FROM_AUTHENTICATOR;
 
 /**
  * Class containing the test cases for EmailOTPAuthenticatorTest class.
@@ -112,6 +118,7 @@ public class EmailOTPAuthenticatorTest {
     private CaptchaDataHolder captchaDataHolder;
     private AuthenticatedUser authenticatedUserFromContext;
     private IdpManager idpManager;
+    private AuthenticatedUser authenticatedUser;
 
     private MockedStatic<ConfigurationFacade> staticConfigurationFacade;
     private MockedStatic<FrameworkUtils> frameworkUtils;
@@ -153,6 +160,7 @@ public class EmailOTPAuthenticatorTest {
         captchaDataHolder = mock(CaptchaDataHolder.class);
         multiAttributeLoginService = mock(MultiAttributeLoginService.class);
         idpManager = mock(IdpManager.class);
+        authenticatedUser = mock(AuthenticatedUser.class);
 
         staticConfigurationFacade = mockStatic(ConfigurationFacade.class);
         frameworkUtils = mockStatic(FrameworkUtils.class);
@@ -181,8 +189,7 @@ public class EmailOTPAuthenticatorTest {
     }
 
     @Test(description = "Test isRetrying in OTP Authenticators",
-            dataProvider = "authenticatorProvider",
-            expectedExceptions = NullPointerException.class)
+            dataProvider = "authenticatorProvider")
     public void testIsRetryingInOTPAuthenticators(String currentAuthenticator)
             throws AuthenticationFailedException, LogoutFailedException {
 
@@ -193,7 +200,10 @@ public class EmailOTPAuthenticatorTest {
 
         context.setCurrentAuthenticator(currentAuthenticator);
 
-        emailOTPAuthenticator.process(httpServletRequest, httpServletResponse, context);
+        try {
+            emailOTPAuthenticator.process(httpServletRequest, httpServletResponse, context);
+        } catch (NullPointerException ignored) {
+        }
         Assert.assertFalse(context.isRetrying());
     }
 
@@ -203,6 +213,141 @@ public class EmailOTPAuthenticatorTest {
         when(httpServletRequest.getParameter(AuthenticatorConstants.CODE)).thenReturn(null);
         when(httpServletRequest.getParameter(AuthenticatorConstants.USER_NAME)).thenReturn(null);
         Assert.assertFalse(emailOTPAuthenticator.canHandle(httpServletRequest));
+    }
+
+    @DataProvider(name = "OTPParams")
+    public Object[][] provideOTPParams() {
+
+        return new Object[][]{
+                {AuthenticatorConstants.CODE},
+                {AuthenticatorConstants.CODE_LOWERCASE}
+        };
+    }
+
+    @Test(description = "Test case for getParameterNames() method.", dataProvider = "OTPParams")
+    public void testGetParameterNames(String otpParam) {
+
+        when(httpServletRequest.getParameter(AuthenticatorConstants.RESEND)).thenReturn(AuthenticatorConstants.RESEND);
+        when(httpServletRequest.getParameterNames()).thenReturn(Collections.enumeration(
+                Collections.singletonList(otpParam)));
+        Assert.assertTrue(emailOTPAuthenticator.canHandle(httpServletRequest));
+    }
+
+    @Test(
+            description = "Test case for processAuthenticationResponse() method when the OTP token is empty " +
+                    "for the authenticated user, expecting an InvalidCredentialsException.",
+            expectedExceptions = InvalidCredentialsException.class,
+            expectedExceptionsMessageRegExp = "OTP token is empty for user: .*"
+    )
+    public void testProcessAuthenticationResponseWithEmptyOtpToken() throws AuthenticationFailedException {
+
+        setAuthenticatorConfig();
+        configureAuthenticatedUser(false);
+        emailOTPAuthenticator.processAuthenticationResponse(httpServletRequest, httpServletResponse, context);
+    }
+
+    @Test(dataProvider = "ScenarioDataProvider", description = "Test case for resolveScenario() method.")
+    public void testResolveScenario(String authenticator, boolean isLogoutRequest, boolean isRetrying,
+                                    String resendCode, String codeParam, String code,
+                                    AuthenticatorConstants.AuthenticationScenarios expectedScenario) throws Exception {
+
+        context.setCurrentAuthenticator(authenticator);
+        context.setRetrying(isRetrying);
+        context.setLogoutRequest(isLogoutRequest);
+
+        when(httpServletRequest.getParameter(AuthenticatorConstants.RESEND)).thenReturn(resendCode);
+        when(httpServletRequest.getParameter(codeParam)).thenReturn(code);
+        when(httpServletRequest.getParameter(AuthenticatorConstants.USER_NAME)).thenReturn(USERNAME);
+
+        Method method = emailOTPAuthenticator.getClass()
+                .getDeclaredMethod("resolveScenario", HttpServletRequest.class, AuthenticationContext.class);
+        method.setAccessible(true);
+        Object result = method.invoke(emailOTPAuthenticator, httpServletRequest, context);
+        Assert.assertEquals(result, expectedScenario);
+    }
+
+    @DataProvider(name = "ScenarioDataProvider")
+    public Object[][] scenarioDataProvider() {
+
+        //AuthenticatorName, isLogoutRequest, isRetrying, resendCode, codeParam, code, expectedScenario
+        return new Object[][]{
+                // Initial OTP scenario where no code is available
+                {"previousAuthenticator", false, false, null, "OTPCode", null,
+                        AuthenticatorConstants.AuthenticationScenarios.INITIAL_OTP},
+                // Initial OTP scenario where code from previous authenticator is available as OTPCode
+                {"previousOTPAuthenticator", false, false, null, "OTPCode", "1234",
+                        AuthenticatorConstants.AuthenticationScenarios.INITIAL_OTP},
+                // Logout scenario
+                {"randomAuthenticator", true, true, "true", "OTPCode", "1234",
+                        AuthenticatorConstants.AuthenticationScenarios.LOGOUT},
+                // Retry scenario
+                {EMAIL_OTP_AUTHENTICATOR_NAME, false, true, null, "OTPCode", "1234",
+                        AuthenticatorConstants.AuthenticationScenarios.SUBMIT_OTP},
+                // Retry is incorrectly set due to previous authenticator
+                {"previousAuthenticator", false, true, null, "OTPCode", null,
+                        AuthenticatorConstants.AuthenticationScenarios.INITIAL_OTP},
+                // Resend scenario
+                {EMAIL_OTP_AUTHENTICATOR_NAME, false, true, "true", "OTPCode", "1234",
+                        AuthenticatorConstants.AuthenticationScenarios.RESEND_OTP},
+        };
+    }
+
+    @Test(dataProvider = "IDFInitiationDataProvider")
+    public void testInitiateAuthenticationRequestForIDFInitiation(boolean isUsernameAvailable, boolean isUserAvailable,
+                                                                  Boolean initialIsIDFInitiatedFromAuthenticator,
+                                                                  Boolean expectedIsIDFInitiatedFromAuthenticator)
+            throws Exception {
+
+        context.setProperty(IS_IDF_INITIATED_FROM_AUTHENTICATOR, initialIsIDFInitiatedFromAuthenticator);
+        if (isUsernameAvailable) {
+            when(httpServletRequest.getParameter(AuthenticatorConstants.USER_NAME)).thenReturn(USERNAME);
+        } else {
+            when(httpServletRequest.getParameter(AuthenticatorConstants.USER_NAME)).thenReturn(null);
+        }
+        context.setCurrentStep(2);
+        SequenceConfig sequenceConfig = new SequenceConfig();
+        StepConfig stepConfig = new StepConfig();
+        stepConfig.setSubjectAttributeStep(true);
+        Map<Integer, StepConfig> stepConfigMap = new HashMap<>();
+        stepConfigMap.put(2, stepConfig);
+        sequenceConfig.setStepMap(stepConfigMap);
+        context.setSequenceConfig(sequenceConfig);
+
+        if (isUserAvailable) {
+            AuthenticatedUser user = new AuthenticatedUser();
+            user.setFederatedUser(true);
+            user.setAuthenticatedSubjectIdentifier(USERNAME);
+            stepConfig.setAuthenticatedUser(user);
+        }
+
+        when(ConfigurationFacade.getInstance()).thenReturn(configurationFacade);
+        when(configurationFacade.getAuthenticationEndpointURL()).thenReturn(DUMMY_LOGIN_PAGE_URL);
+
+        try {
+            Method method = emailOTPAuthenticator.getClass()
+                    .getDeclaredMethod("initiateAuthenticationRequest",
+                            HttpServletRequest.class,
+                            HttpServletResponse.class,
+                            AuthenticationContext.class);
+            method.setAccessible(true);
+            method.invoke(emailOTPAuthenticator, httpServletRequest, httpServletResponse, context);
+        } catch (InvocationTargetException e) {
+            // Ignore the exception
+        }
+
+        Assert.assertEquals(context.getProperty(IS_IDF_INITIATED_FROM_AUTHENTICATOR),
+                expectedIsIDFInitiatedFromAuthenticator);
+
+    }
+
+    @DataProvider(name = "IDFInitiationDataProvider")
+    public Object[][] iDFInitiationDataProvider() {
+
+        return new Object[][]{
+                {true, false, true, null},
+                {false, false, null, true},
+                {false, true, null, null},
+        };
     }
 
     @Test(description = "Test case for process() method when authenticated user is null " +
@@ -217,8 +362,7 @@ public class EmailOTPAuthenticatorTest {
         AuthenticatorFlowStatus status = emailOTPAuthenticator.process(httpServletRequest, httpServletResponse,
                 context);
         assertEquals(status, AuthenticatorFlowStatus.INCOMPLETE);
-        Assert.assertTrue(((boolean) context.getProperty(
-                AuthenticatorConstants.IS_IDF_INITIATED_FROM_AUTHENTICATOR)));
+        Assert.assertTrue(((boolean) context.getProperty(IS_IDF_INITIATED_FROM_AUTHENTICATOR)));
 
         User user = new User(UUID.randomUUID().toString(), USERNAME, null);
         user.setUserStoreDomain(USER_STORE_DOMAIN);
@@ -303,7 +447,7 @@ public class EmailOTPAuthenticatorTest {
         Map<Integer, StepConfig> stepConfigMap = new HashMap<>();
 
         StepConfig emailOTPStep = new StepConfig();
-        authenticatorConfig.setName(AuthenticatorConstants.EMAIL_OTP_AUTHENTICATOR_NAME);
+        authenticatorConfig.setName(EMAIL_OTP_AUTHENTICATOR_NAME);
         List<AuthenticatorConfig> authenticatorList = new ArrayList<>();
         authenticatorList.add(authenticatorConfig);
         emailOTPStep.setAuthenticatorList(authenticatorList);
@@ -347,7 +491,7 @@ public class EmailOTPAuthenticatorTest {
                 0, Boolean.FALSE, AuthenticatorConstants.USERNAME_PARAM);
         authenticatorParamMetadataList.add(usernameMetadata);
 
-        assertEquals(authenticatorDataObj.getName(), AuthenticatorConstants.EMAIL_OTP_AUTHENTICATOR_NAME);
+        assertEquals(authenticatorDataObj.getName(), EMAIL_OTP_AUTHENTICATOR_NAME);
         assertEquals(authenticatorDataObj.getDisplayName(),
                 AuthenticatorConstants.EMAIL_OTP_AUTHENTICATOR_FRIENDLY_NAME,
                 "Authenticator display name should match.");
@@ -388,7 +532,7 @@ public class EmailOTPAuthenticatorTest {
             claimMap.put(LOCALE_CLAIM, SAMPLE_LOCALE);
         }
         setAuthenticatorConfig();
-        configureAuthenticatedUser();
+        configureAuthenticatedUser(true);
         configureAuthenticatorDataHolder();
         configureIdentityProvider();
 
@@ -441,13 +585,13 @@ public class EmailOTPAuthenticatorTest {
         AuthenticatorDataHolder.setIdpManager(idpManager);
     }
 
-    private void configureAuthenticatedUser() {
+    private void configureAuthenticatedUser(boolean isFederated) {
 
         AuthenticatedUser authenticatedUser = new AuthenticatedUser();
         authenticatedUser.setUserStoreDomain(USER_STORE_DOMAIN);
         authenticatedUser.setUserName(USERNAME);
         authenticatedUser.setTenantDomain(TENANT_DOMAIN);
-        authenticatedUser.setFederatedUser(true);
+        authenticatedUser.setFederatedUser(isFederated);
         context.setSubject(authenticatedUser);
     }
 


### PR DESCRIPTION
### Purpose

- Add the support for both OTPCode and OTPcode parameters
- Fix issues when sending OTP Code if OTP Code is available from previous authenticator
- Reset the IS_IDF_INITIATED_FROM_AUTHENTICATOR parameters when not applicable

### Related Issues
- https://github.com/wso2/product-is/issues/23668