### PR TITLE
Add custom template to the Email OTP from runtime params through adaptive script

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
@@ -730,6 +730,12 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
         }
         metaProperties.put(CODE, otp);
         metaProperties.put(EMAIL_TEMPLATE_TYPE, AuthenticatorConstants.EMAIL_OTP_TEMPLATE_NAME);
+        Map<String, String> emailOtpAuthenticatorParams = getRuntimeParams(context);
+        String emailTemplateType = emailOtpAuthenticatorParams.get(
+                AuthenticatorConstants.EMAIL_NOTIFICATION_TEMPLATE_TYPE);
+        if (StringUtils.isNotBlank(emailTemplateType)) {
+            metaProperties.put(EMAIL_TEMPLATE_TYPE, emailTemplateType);
+        }
         metaProperties.put(ARBITRARY_SEND_TO, email);
         String maskedEmailAddress = getMaskedEmailAddress(authenticatedUser.getUserName(), email, tenantDomain,
                 context);

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
@@ -36,6 +36,7 @@ public class AuthenticatorConstants {
     public static final long DEFAULT_EMAIL_OTP_VALIDITY_IN_MILLIS = 300000;
     public static final int DEFAULT_OTP_LENGTH = 6;
     public static final String DEFAULT_EMAIL_MASKING_REGEX = "(?<=.{3}).(?=[^@]*?@)";
+    public static final String EMAIL_NOTIFICATION_TEMPLATE_TYPE = "notificationTemplate";
 
     public static final String USERNAME_PARAM = "username.param";
     public static final String CODE_PARAM = "code.param";


### PR DESCRIPTION
 ## Purpose
> Part of the fix for : https://github.com/wso2/product-is/issues/24128

## Testsing
1. Configuring the params. `notificationTemplate` is the name of the Email template that we need to send the email.
```
executeStep(2, {
    authenticationOptions: '"Email OTP"',
    authenticatorParams: {
        local: {
            'email-otp-authenticator': {
                notificationTemplate: "Custom Email OTP Template"
            }
        }
    }
}, {});
```
2. With custom template data in adaptive script

![Screenshot 2025-06-03 at 9 48 33 AM](https://github.com/user-attachments/assets/507048b5-e73c-4260-8589-a25822aea0e5)

3. Without custom data in adaptive script

![Screenshot 2025-06-03 at 9 51 28 AM](https://github.com/user-attachments/assets/6fc96816-5d1e-41ba-8539-1a28912b26b6)

## Goals
> Allowing to decide what is the template type that we need to send for the Email OTP