### PR TITLE
Add support for flow type properties in Email OTP executor

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPExecutor.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPExecutor.java
@@ -43,12 +43,16 @@ import java.util.Map;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.EMAIL_ADDRESS_CLAIM;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.USERNAME_CLAIM;
 import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.CODE;
+import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.CONFIRMATION_CODE;
 import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.LogConstants.EMAIL_OTP_SERVICE;
 
 /**
  * Email OTP executor for user registration.
  */
 public class EmailOTPExecutor extends AbstractOTPExecutor {
+
+    private static final String PASSWORD_RECOVERY = "PASSWORD_RECOVERY";
+    private static final String REGISTRATION = "REGISTRATION";
 
     @Override
     public String getName() {
@@ -74,13 +78,13 @@ public class EmailOTPExecutor extends AbstractOTPExecutor {
     @Override
     protected Event getSendOTPEvent(OTPExecutorConstants.OTPScenarios scenario, OTP otp, FlowExecutionContext context) {
 
+        FlowTypeProperties flowProperties = resolveFlowTypeProperties(context);
         String tenantDomain = context.getTenantDomain();
         String email = String.valueOf(context.getFlowUser().getClaim(EMAIL_ADDRESS_CLAIM));
 
         Map<String, Object> eventProperties = new HashMap<>();
-        eventProperties.put(CODE, otp.getValue());
-        eventProperties.put(NotificationConstants.EmailNotification.EMAIL_TEMPLATE_TYPE,
-                ExecutorConstants.EMAIL_OTP_VERIFY_TEMPLATE);
+        eventProperties.put(flowProperties.codeKey, otp.getValue());
+        eventProperties.put(NotificationConstants.EmailNotification.EMAIL_TEMPLATE_TYPE, flowProperties.templateType);
         eventProperties.put(NotificationConstants.ARBITRARY_SEND_TO, email);
         eventProperties.put(NotificationConstants.TENANT_DOMAIN, tenantDomain);
 
@@ -166,5 +170,28 @@ public class EmailOTPExecutor extends AbstractOTPExecutor {
     protected String getDiagnosticLogComponentId() {
 
         return EMAIL_OTP_SERVICE;
+    }
+
+    private FlowTypeProperties resolveFlowTypeProperties(FlowExecutionContext flowExecutionContext) {
+
+        switch (flowExecutionContext.getFlowType()) {
+            case REGISTRATION:
+                return new FlowTypeProperties(CODE, ExecutorConstants.EMAIL_OTP_VERIFY_TEMPLATE);
+            case PASSWORD_RECOVERY:
+                return new FlowTypeProperties(CONFIRMATION_CODE, ExecutorConstants.EMAIL_OTP_PASSWORD_RESET_TEMPLATE);
+            default:
+                return new FlowTypeProperties(null, null);
+        }
+    }
+
+    private static class FlowTypeProperties {
+
+        final String codeKey;
+        final String templateType;
+
+        FlowTypeProperties(String codeKey, String templateType) {
+            this.codeKey = codeKey;
+            this.templateType = templateType;
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
@@ -49,6 +49,7 @@ public class AuthenticatorConstants {
 
     public static final String RESEND = "resendCode";
     public static final String CODE = "OTPCode";
+    public static final String CONFIRMATION_CODE = "confirmation-code";
     public static final String CODE_LOWERCASE = "OTPcode";
     public static final String DISPLAY_CODE = "Code";
     public static final String OTP_TOKEN = "otpToken";

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/ExecutorConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/ExecutorConstants.java
@@ -29,6 +29,7 @@ public class ExecutorConstants {
 
     public static final String EMAIL_OTP_EXECUTOR_NAME = "EmailOTPExecutor";
     public static final String EMAIL_OTP_VERIFY_TEMPLATE = "EmailOTPVerification";
+    public static final String EMAIL_OTP_PASSWORD_RESET_TEMPLATE = "passwordResetOTP";
     public static final String EMAIL_VERIFIED_CLAIM_URI = "http://wso2.org/claims/identity/emailVerified";
     public static final String VERIFIED_EMAIL_ADDRESSES_CLAIM_URI = "http://wso2.org/claims/verifiedEmailAddresses";
 }


### PR DESCRIPTION
This pull request introduces enhancements to the `EmailOTPExecutor` class to support multiple OTP flow types, such as registration and password recovery, by dynamically resolving flow-specific properties. It also includes updates to constants and test cases to ensure proper functionality and coverage.

### Enhancements to `EmailOTPExecutor`:

* Added a private method `resolveFlowTypeProperties` to dynamically determine flow-specific properties (`codeKey` and `templateType`) based on the flow type (e.g., registration or password recovery). This improves flexibility for handling different OTP scenarios. [[1]](diffhunk://#diff-b40102d3b73a10e3822a745067b703eea0a0c95d56fc824c00ded2488d99290cR78-R84) [[2]](diffhunk://#diff-b40102d3b73a10e3822a745067b703eea0a0c95d56fc824c00ded2488d99290cR171-R193)
* Updated the `getSendOTPEvent` method to use the dynamically resolved flow properties instead of hardcoded values.

### Updates to constants:

* Added `CONFIRMATION_CODE` to `AuthenticatorConstants` for password recovery flow.
* Added `EMAIL_OTP_PASSWORD_RESET_TEMPLATE` to `ExecutorConstants` for password reset scenarios.

### Test case improvements:

* Added a `DataProvider` and a new test method `testResolveFlowTypeProperties` to validate the behavior of the `resolveFlowTypeProperties` method across different flow types. This ensures proper functionality for registration, password recovery, and unknown flow types.
* Updated existing test cases to mock flow type values and verify correct handling of flow-specific properties. [[1]](diffhunk://#diff-54cf5dc73ba736ff521e7d5c1eb3dfb1caa5fa956c024d854f6ab1778d87eae5R100) [[2]](diffhunk://#diff-54cf5dc73ba736ff521e7d5c1eb3dfb1caa5fa956c024d854f6ab1778d87eae5R126)