### PR TITLE
Override getAMRValue method

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPExecutor.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPExecutor.java
@@ -62,6 +62,12 @@ public class EmailOTPExecutor extends AbstractOTPExecutor {
     }
 
     @Override
+    public String getAMRValue() {
+
+        return AuthenticatorConstants.EMAIL_OTP_AUTHENTICATOR_NAME;
+    }
+
+    @Override
     public List<String> getInitiationData() {
 
         List<String> initiationData = new ArrayList<>();

--- a/pom.xml
+++ b/pom.xml
@@ -322,12 +322,12 @@
         <identity.auth.otp.commons.version.range>[1.0.0, 2.0.0)</identity.auth.otp.commons.version.range>
 
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
-        <carbon.identity.framework.version>7.8.215</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.403</carbon.identity.framework.version>
         <carbon.identity.governance.version>1.8.40</carbon.identity.governance.version>
         <carbon.identity.handler.event.account.lock.version>1.8.2</carbon.identity.handler.event.account.lock.version>
         <carbon.extension.identity.helper.version>1.0.12</carbon.extension.identity.helper.version>
         <carbon.identity.event.handler.notification.version>1.9.45</carbon.identity.event.handler.notification.version>
-        <identity.auth.otp.commons.version>1.0.12</identity.auth.otp.commons.version>
+        <identity.auth.otp.commons.version>1.0.16</identity.auth.otp.commons.version>
         <owasp.encoder.version>1.2.0.wso2v1</owasp.encoder.version>
         <mockito-inline.version>3.8.0</mockito-inline.version>
 


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/24768

### Depends on

https://github.com/wso2-extensions/identity-auth-otp-commons/pull/22

This pull request introduces a new method to support authentication mechanisms and updates several dependency versions to keep the project up-to-date and compatible with the latest features and fixes.

Authentication mechanism support:

* Added the `getAMRValue()` method to the `EmailOTPExecutor` class, which returns the appropriate Authentication Method Reference (AMR) value for Email OTP authentication.

Dependency version updates:

* Updated the `carbon.identity.framework.version` from `7.8.215` to `7.8.403` in `pom.xml` to use a newer framework version.
* Updated the `identity.auth.otp.commons.version` from `1.0.12` to `1.0.16` in `pom.xml` for improved compatibility and bug fixes.