### PR TITLE
Handle email not existing flow

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPExecutor.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPExecutor.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.local.auth.emailotp;
 
+import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.auth.otp.core.AbstractOTPExecutor;
 import org.wso2.carbon.identity.auth.otp.core.constant.OTPExecutorConstants;
 import org.wso2.carbon.identity.auth.otp.core.model.OTP;
@@ -177,6 +178,12 @@ public class EmailOTPExecutor extends AbstractOTPExecutor {
     protected String getDiagnosticLogComponentId() {
 
         return EMAIL_OTP_SERVICE;
+    }
+
+    @Override
+    protected boolean validateInitiation(FlowExecutionContext context) {
+
+        return StringUtils.isNotBlank((String) context.getFlowUser().getClaim(EMAIL_ADDRESS_CLAIM));
     }
 
     private FlowTypeProperties resolveFlowTypeProperties(FlowExecutionContext flowExecutionContext) {

--- a/pom.xml
+++ b/pom.xml
@@ -327,7 +327,7 @@
         <carbon.identity.handler.event.account.lock.version>1.8.2</carbon.identity.handler.event.account.lock.version>
         <carbon.extension.identity.helper.version>1.0.12</carbon.extension.identity.helper.version>
         <carbon.identity.event.handler.notification.version>1.9.45</carbon.identity.event.handler.notification.version>
-        <identity.auth.otp.commons.version>1.0.18</identity.auth.otp.commons.version>
+        <identity.auth.otp.commons.version>1.0.22</identity.auth.otp.commons.version>
         <owasp.encoder.version>1.2.0.wso2v1</owasp.encoder.version>
         <mockito-inline.version>3.8.0</mockito-inline.version>
 


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25636

This pull request introduces a validation improvement to the `EmailOTPExecutor` class, ensuring that the OTP flow can only be initiated if the user's email address claim is present and not blank.

Enhancement to initiation validation:

* Added a `validateInitiation` method override to `EmailOTPExecutor` that checks if the user's email address claim is not blank using `StringUtils.isNotBlank`. This helps prevent OTP flows from starting without a valid email address.
* Imported `org.apache.commons.lang.StringUtils` to support the new validation logic.