### PR TITLE
Handle multiple users scenario in EmailOTP authenticator to prevent enumeration attacks

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
@@ -228,7 +228,22 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
 
             // When username is obtained through IDF page and the user is not yet set in the context.
             AuthenticatedUser authenticatedUser = resolveUser(request, context);
-            user = getUser(authenticatedUser, context);
+            try {
+                user = getUser(authenticatedUser, context);
+            } catch (AuthenticationFailedException e) {
+                // Check if the exception is specifically about multiple users
+                if (e.getMessage() != null && e.getMessage().contains(AuthenticatorConstants.MULTIPLE_USERS_ERROR_MESSAGE)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Multiple users found for the provided username", e);
+                    }
+                    
+                    if (isEmailOTPAsFirstFactor(context) && Boolean.parseBoolean(IdentityUtil.getProperty(HIDE_USER_EXISTENCE_CONFIG))) {
+                        redirectToEmailOTPLoginPage(null, null, context.getTenantDomain(), response, request, context);
+                        return;
+                    }
+                }
+                throw e;
+            }
             if ((resolveUsernameFromRequest(request) != null) && (user == null)) {
                 context.setProperty(IS_USER_NAME_RESOLVED, false);
             }

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
@@ -102,6 +102,7 @@ public class AuthenticatorConstants {
     public static final String DISPLAY_USER_NAME = "Username";
     public static final String IS_REDIRECT_TO_EMAIL_OTP = "isRedirectToEmailOTP";
     public static final String CONF_SHOW_AUTH_FAILURE_REASON = "showAuthFailureReason";
+    public static final String MULTIPLE_USERS_ERROR_MESSAGE = "There are more than one user with the provided username";
 
     /**
      * Authenticator config related configurations.


### PR DESCRIPTION
## Purpose
Prevents user enumeration attacks by catching multiple users exceptions in EmailOTP authenticator and redirecting to OTP input page with consistent behavior.