### PR TITLE
Use context-tenant-based username preprocessing in Email OTP Authenticator

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
@@ -1607,7 +1607,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
             throws AuthenticationFailedException {
 
         String username = resolveUsernameFromRequest(request);
-        username = FrameworkUtils.preprocessUsername(username, context);
+        username = FrameworkUtils.preprocessUsernameWithContextTenantDomain(username, context);
         AuthenticatedUser user = new AuthenticatedUser();
         String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
         String userStoreDomain = UserCoreUtil.extractDomainFromName(username);


### PR DESCRIPTION
### Purpose
Update the Email OTP Authenticator to use the newly introduced username preprocessing method that relies on the context tenant domain. This ensures consistent username handling with the context-aware logic used across components.

### Goals
* Replace the existing use of `FrameworkUtils.preprocessUsername()` with the new context-based variant.
* Maintain consistent and reliable username preprocessing behavior.

### Approach
* Updated the call in `EmailOTPAuthenticator` to use `FrameworkUtils.preprocessUsernameWithContextTenantDomain()`.
* No functional changes other than switching to the context-tenant-based preprocessing method.