### PR TITLE
Fix email OTP tenanted flow for non-SaaS org login

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
@@ -956,20 +956,19 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                 context);
         setAuthenticatorMessage(context, maskedEmailAddress);
 
-        /* SaaS apps are created at the super tenant level and they can be accessed by users of other organizations.
-        If users of other organizations try to login to a saas app, the email notification should be triggered from the
-        email provider configured for that organization. Hence, we need to start a new tenanted flow here. */
-        if (context.getSequenceConfig().getApplicationConfig().isSaaSApp()) {
-            try {
-                FrameworkUtils.startTenantFlow(authenticatedUser.getTenantDomain());
-                triggerEvent(IdentityEventConstants.Event.TRIGGER_NOTIFICATION, authenticatedUser, metaProperties,
-                        context);
-            } finally {
-                FrameworkUtils.endTenantFlow();
-            }
-        } else {
+        /* When users from a different organization try to login (e.g., SaaS apps accessed by sub-org users, or
+        non-SaaS apps with Organization Login Enhanced where sub-org users authenticate via root org app), the email
+        notification should be triggered from the email provider configured for the user's organization. Hence, we
+        need to start a new tenanted flow with the authenticated user's tenant domain. */
+        if (!context.getSequenceConfig().getApplicationConfig().isSaaSApp()) {
             metaProperties.put(IdentityEventConstants.EventProperty.APPLICATION_DOMAIN, tenantDomain);
-            triggerEvent(IdentityEventConstants.Event.TRIGGER_NOTIFICATION, authenticatedUser, metaProperties, context);
+        }
+        try {
+            FrameworkUtils.startTenantFlow(authenticatedUser.getTenantDomain());
+            triggerEvent(IdentityEventConstants.Event.TRIGGER_NOTIFICATION, authenticatedUser, metaProperties,
+                    context);
+        } finally {
+            FrameworkUtils.endTenantFlow();
         }
         if (LoggerUtils.isDiagnosticLogsEnabled()) {
             DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(


### PR DESCRIPTION
## Summary
- Start tenanted flow with the authenticated user's tenant domain for all login scenarios, not just SaaS apps
- Ensures email notifications use the correct organization's email provider when sub-org users authenticate via root org apps with Organization Login Enhanced
- Non-SaaS apps still set the `APPLICATION_DOMAIN` meta property as before

## Test plan
- [ ] SaaS app: sub-org user logs in → email OTP sent from sub-org's configured email provider
- [ ] Non-SaaS app with Organization Login Enhanced: sub-org user authenticates via root org app → email OTP sent from sub-org's email provider (previously used root org's provider)
- [ ] Non-SaaS app: regular tenant user logs in → email OTP works as before with `APPLICATION_DOMAIN` set