### PR TITLE
Address Review Comments on #37.

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
@@ -528,7 +528,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                         AuthenticatorConstants.ErrorMessages.ERROR_CODE_RETRYING_OTP_RESEND,
                         (String) context.getProperty(INVALID_USERNAME));
             }
-            handleInvalidOTPLoginAttempt(context, applicationTenantDomain);
+            handleInvalidOTPLoginAttempt(context);
             throw handleAuthErrorScenario(AuthenticatorConstants.ErrorMessages.ERROR_CODE_NO_USER_FOUND, context);
         } else if (isPreviousIdPAuthenticationFlowHandler(context)) {
             User user = getUser(authenticatedUserFromContext);
@@ -552,7 +552,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                 mappedLocalUsername, applicationTenantDomain, isInitialFederationAttempt, context);
         String codeParam = getCurrentCodeParam(request);
         if (StringUtils.isBlank(request.getParameter(codeParam)) && !isResendAttempt) {
-            handleInvalidOTPLoginAttempt(context, applicationTenantDomain);
+            handleInvalidOTPLoginAttempt(context);
             throw handleInvalidCredentialsScenario(AuthenticatorConstants.ErrorMessages.ERROR_CODE_EMPTY_OTP_CODE,
                     authenticatedUserFromContext.getUserName());
         }
@@ -620,7 +620,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
             }
         }
 
-        handleInvalidOTPLoginAttempt(context, applicationTenantDomain);
+        handleInvalidOTPLoginAttempt(context);
 
         if (Boolean.parseBoolean(context.getProperty(AuthenticatorConstants.OTP_EXPIRED).toString())) {
             publishPostEmailOTPValidatedEvent(authenticatedUserFromContext, false,
@@ -2057,7 +2057,13 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
             throws AuthenticationFailedException {
 
         int maxRetryAttempts = getMaximumRetryAttempts(context);
-        int currentRetryAttempts = getCurrentRetryAttempt(context);
+        int currentRetryAttempts;
+        try {
+            currentRetryAttempts = getCurrentRetryAttempt(context);
+        } catch (NumberFormatException e) {
+            throw new AuthenticationFailedException("Error while parsing the current retry attempt count from context",
+                    e);
+        }
         int remainingRetryAttempts = maxRetryAttempts - currentRetryAttempts;
         // If the remaining retry attempts is less than 0, then return 0.
         return Math.max(remainingRetryAttempts, 0);
@@ -2241,17 +2247,25 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
      * if the count has exceeded the allowed limit for the context.
      *
      * @param context Authentication context.
-     * @param applicationTenantDomain Application tenant domain.
-     * @throws AuthenticationFailedException If an error occurs while handling the retry blocking scenario.
      */
-    private void handleInvalidOTPLoginAttempt(AuthenticationContext context, String applicationTenantDomain)
-            throws AuthenticationFailedException {
+    private void handleInvalidOTPLoginAttempt(AuthenticationContext context) {
 
         if (isContextBasedRetryBlockingEnabled(context)) {
             // Update Context based retry counter only if context based retry blocking is enabled.
             updateContextOTPRetryCount(context);
             int maxRetryAttempts = getMaximumRetryAttempts(context);
-            int currentRetryAttempts = getCurrentRetryAttempt(context);
+            int currentRetryAttempts;
+            try {
+                currentRetryAttempts = getCurrentRetryAttempt(context);
+            } catch (NumberFormatException e) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Error while parsing the current retry attempt count from context", e);
+                }
+                // If there is an error while getting the current retry attempt count, handle it as retry count
+                // exceeded scenario.
+                handleOTPRetryCountExceededScenario(context);
+                return;
+            }
             if (currentRetryAttempts >= maxRetryAttempts) {
                 handleOTPRetryCountExceededScenario(context);
             }
@@ -2263,10 +2277,8 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
      * based on the configuration.
      *
      * @param context  AuthenticationContext.
-     * @throws AuthenticationFailedException If an error occurred.
      */
-    private void handleOTPRetryCountExceededScenario(AuthenticationContext context)
-            throws AuthenticationFailedException {
+    private void handleOTPRetryCountExceededScenario(AuthenticationContext context) {
 
         context.setProperty(SKIP_RETRY_FROM_AUTHENTICATOR, true);
         context.setProperty(FrameworkConstants.AUTH_ERROR_CODE,
@@ -2280,11 +2292,9 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
      * @param scenario The current authentication scenario.
      * @param context Authentication context.
      * @return true if it's an OTP resend attempt and the resend limit has been exceeded, false otherwise.
-     * @throws AuthenticationFailedException If an error occurs while checking the resend limit.
      */
     private boolean isOTPResendLimitExceededScenario(AuthenticatorConstants.AuthenticationScenarios scenario,
-                                                     AuthenticationContext context)
-            throws AuthenticationFailedException {
+                                                     AuthenticationContext context) {
 
         return scenario == AuthenticatorConstants.AuthenticationScenarios.RESEND_OTP
                 && isContextBasedOTPResendBlockingEnabled(context)
@@ -2296,13 +2306,19 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
      *
      * @param context Authentication context.
      * @return true if the resend count has exceeded, false otherwise.
-     * @throws AuthenticationFailedException If an error occurs while checking the resend count.
      */
-    private boolean isOTPResendLimitExceeded(AuthenticationContext context)
-            throws AuthenticationFailedException {
+    private boolean isOTPResendLimitExceeded(AuthenticationContext context) {
 
         int allowedResendAttemptsCount = getMaximumResendAttemptsFromContext(context);
-        int currentResendAttempt = getCurrentResendAttempt(context);
+        int currentResendAttempt;
+        try {
+            currentResendAttempt = getCurrentResendAttempt(context);
+        } catch (NumberFormatException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Error while parsing the current resend attempt count from context", e);
+            }
+            return true;
+        }
         return currentResendAttempt >= allowedResendAttemptsCount;
     }
 
@@ -2311,10 +2327,8 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
      *
      * @param context Authentication Context.
      * @return The maximum number of retry attempts.
-     * @throws AuthenticationFailedException If an error occurs when retrieving config.
      */
-    private int getMaximumRetryAttempts(AuthenticationContext context)
-            throws AuthenticationFailedException {
+    private int getMaximumRetryAttempts(AuthenticationContext context) {
 
         if (isContextBasedRetryBlockingEnabled(context)) {
             OptionalInt maxRetryAttemptsFromContext = AuthenticatorUtils.getIntRuntimeParamByName(
@@ -2361,7 +2375,16 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                 StringUtils.isBlank(context.getProperty(key).toString())) {
             context.setProperty(key, 1);
         } else {
-            context.setProperty(key, (int) context.getProperty(key) + 1);
+            int currentCount;
+            try {
+                currentCount = Integer.parseInt(context.getProperty(key).toString());
+            } catch (NumberFormatException e) {
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("Error while parsing the current count for context property: %s.", key), e);
+                }
+                return;
+            }
+            context.setProperty(key, currentCount + 1);
         }
     }
 
@@ -2425,7 +2448,6 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
 
     /**
      * Get the context property key used to store the OTP resend attempt count.
-     * Subclasses may override this to use a different key.
      *
      * @return The context property key for OTP resend attempts.
      */
@@ -2436,7 +2458,6 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
 
     /**
      * Get the context property key used to store the OTP retry attempt count.
-     * Subclasses may override this to use a different key.
      *
      * @return The context property key for OTP retry attempts.
      */
@@ -2463,10 +2484,8 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
      *
      * @param context Authentication context.
      * @return true if enabled, false otherwise.
-     * @throws AuthenticationFailedException If an error occurs while checking the configuration.
      */
-    protected boolean isContextBasedOTPResendBlockingEnabled(AuthenticationContext context)
-            throws AuthenticationFailedException {
+    protected boolean isContextBasedOTPResendBlockingEnabled(AuthenticationContext context) {
 
         OptionalInt maximumAllowedResendAttemptsLimit =
                 AuthenticatorUtils.getIntRuntimeParamByName(getRuntimeParams(context),
@@ -2496,10 +2515,8 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
      * Check whether context based retry blocking is enabled.
      *
      * @return true if enabled, false otherwise.
-     * @throws AuthenticationFailedException If an error occurs while checking the configuration.
      */
-    protected boolean isContextBasedRetryBlockingEnabled(AuthenticationContext context)
-            throws AuthenticationFailedException {
+    protected boolean isContextBasedRetryBlockingEnabled(AuthenticationContext context) {
 
         OptionalInt maximumAllowedRetryAttemptsLimit =
                 AuthenticatorUtils.getIntRuntimeParamByName(getRuntimeParams(context),
@@ -2514,7 +2531,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                         String.format("Invalid value: %d for maximum allowed retry attempts limit. " +
                                 "The value should be a positive integer.", retryLimit));
             }
-            AuthenticatorUtils.triggerDiagnosticLog(getName(),
+            AuthenticatorUtils.triggerDiagnosticLog(EMAIL_OTP_SERVICE,
                     AuthenticatorConstants.LogConstants.ActionIDs.GET_MAX_FAILURE_LIMIT,
                     "Invalid value: " + retryLimit + " for maximum allowed failure attempts limit. " +
                             "The value should be a positive integer.",
@@ -2529,10 +2546,8 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
      * Check whether the authentication flow should be terminated when the OTP resend limit is exceeded.
      *
      * @return true if the flow should be terminated, false otherwise.
-     * @throws AuthenticationFailedException If an error occurs while checking the configuration.
      */
-    protected boolean isTerminateOnResendLimitExceeded(AuthenticationContext context)
-            throws AuthenticationFailedException {
+    protected boolean isTerminateOnResendLimitExceeded(AuthenticationContext context) {
 
         Optional<Boolean> terminateOnResendLimitExceededParam =
                 AuthenticatorUtils.getBooleanRuntimeParamByName(getRuntimeParams(context),

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
@@ -118,7 +118,6 @@ public class AuthenticatorConstants {
     // Runtime Params.
     public static final String MAXIMUM_ALLOWED_FAILURE_LIMIT = "maximumAllowedFailureAttempts";
     public static final String MAXIMUM_RESEND_LIMIT = "maximumAllowedResendAttempts";
-    public static final String SKIP_RESEND_BLOCK_TIME = "skipResendBlockTime";
     public static final String TERMINATE_ON_RESEND_LIMIT_EXCEEDED = "terminateOnResendLimitExceeded";
 
     /**

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPContextBasedRetryResendTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPContextBasedRetryResendTest.java
@@ -692,8 +692,8 @@ public class EmailOTPContextBasedRetryResendTest {
 
         addRuntimeParamsToContext(MAXIMUM_ALLOWED_FAILURE_LIMIT, "5");
         invokePrivateVoidMethod("handleInvalidOTPLoginAttempt",
-                new Class[]{AuthenticationContext.class, String.class},
-                new Object[]{context, TENANT_DOMAIN});
+                new Class[]{AuthenticationContext.class},
+                new Object[]{context});
         assertEquals(context.getProperty(EMAIL_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME), 1);
     }
 
@@ -701,8 +701,8 @@ public class EmailOTPContextBasedRetryResendTest {
     public void testHandleInvalidOTPLoginAttempt_NoIncrementWhenDisabled() throws Exception {
 
         invokePrivateVoidMethod("handleInvalidOTPLoginAttempt",
-                new Class[]{AuthenticationContext.class, String.class},
-                new Object[]{context, TENANT_DOMAIN});
+                new Class[]{AuthenticationContext.class},
+                new Object[]{context});
         assertNull(context.getProperty(EMAIL_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME));
     }
 
@@ -712,10 +712,74 @@ public class EmailOTPContextBasedRetryResendTest {
         addRuntimeParamsToContext(MAXIMUM_ALLOWED_FAILURE_LIMIT, "2");
         context.setProperty(EMAIL_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME, 1);
         invokePrivateVoidMethod("handleInvalidOTPLoginAttempt",
-                new Class[]{AuthenticationContext.class, String.class},
-                new Object[]{context, TENANT_DOMAIN});
+                new Class[]{AuthenticationContext.class},
+                new Object[]{context});
         assertEquals(context.getProperty(FrameworkConstants.AUTH_ERROR_CODE),
                 FrameworkConstants.ERROR_STATUS_ALLOWED_RETRY_LIMIT_EXCEEDED);
+    }
+
+    @Test(description = "updateContextOTPRetryCount leaves a non-numeric stored value untouched " +
+            "so readers treat it as exceeded")
+    public void testUpdateContextOTPRetryCount_NonNumericValuePreserved() throws Exception {
+
+        context.setProperty(EMAIL_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME, "not-a-number");
+        invokePrivateVoidMethod("updateContextOTPRetryCount",
+                new Class[]{AuthenticationContext.class}, new Object[]{context});
+        assertEquals(context.getProperty(EMAIL_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME), "not-a-number");
+    }
+
+    @Test(description = "updateContextOTPRetryCount handles Long property value by parsing its string form")
+    public void testUpdateContextOTPRetryCount_LongValueIncrementsCorrectly() throws Exception {
+
+        context.setProperty(EMAIL_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME, 4L);
+        invokePrivateVoidMethod("updateContextOTPRetryCount",
+                new Class[]{AuthenticationContext.class}, new Object[]{context});
+        assertEquals(context.getProperty(EMAIL_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME), 5);
+    }
+
+    @Test(description = "handleInvalidOTPLoginAttempt treats a corrupt (non-numeric) retry count as limit exceeded")
+    public void testHandleInvalidOTPLoginAttempt_NonNumericRetryCountTreatedAsExceeded() throws Exception {
+
+        addRuntimeParamsToContext(MAXIMUM_ALLOWED_FAILURE_LIMIT, "5");
+        context.setProperty(EMAIL_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME, "garbage");
+        invokePrivateVoidMethod("handleInvalidOTPLoginAttempt",
+                new Class[]{AuthenticationContext.class},
+                new Object[]{context});
+        // incrementContextCounter leaves the corrupt value untouched; the reader-side NFE handler
+        // in handleInvalidOTPLoginAttempt then routes through handleOTPRetryCountExceededScenario.
+        assertEquals(context.getProperty(FrameworkConstants.AUTH_ERROR_CODE),
+                FrameworkConstants.ERROR_STATUS_ALLOWED_RETRY_LIMIT_EXCEEDED);
+        assertEquals(context.getProperty(AbstractApplicationAuthenticator.SKIP_RETRY_FROM_AUTHENTICATOR), true);
+    }
+
+    @Test(description = "isOTPResendLimitExceeded returns true when stored resend count is non-numeric")
+    public void testIsOTPResendLimitExceeded_NonNumericResendCountReturnsTrue() throws Exception {
+
+        addRuntimeParamsToContext(MAXIMUM_RESEND_LIMIT, "5");
+        context.setProperty(EMAIL_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME, "garbage");
+        boolean result = invokePrivateBooleanMethod("isOTPResendLimitExceeded",
+                new Class[]{AuthenticationContext.class},
+                new Object[]{context});
+        Assert.assertTrue(result);
+    }
+
+    @Test(description = "getRemainingNumberOfContextBasedRetryAttempts wraps NumberFormatException in " +
+            "AuthenticationFailedException")
+    public void testGetRemainingNumberOfContextBasedRetryAttempts_NonNumericThrowsAFE() throws Exception {
+
+        addRuntimeParamsToContext(MAXIMUM_ALLOWED_FAILURE_LIMIT, "5");
+        context.setProperty(EMAIL_OTP_RETRY_ATTEMPTS_CONTEXT_PROPERTY_NAME, "garbage");
+        try {
+            invokePrivateIntMethod("getRemainingNumberOfContextBasedRetryAttempts",
+                    new Class[]{AuthenticationContext.class},
+                    new Object[]{context});
+            Assert.fail("Expected AuthenticationFailedException");
+        } catch (InvocationTargetException e) {
+            Assert.assertTrue(e.getCause() instanceof AuthenticationFailedException,
+                    "Expected AuthenticationFailedException, got: " + e.getCause());
+            Assert.assertTrue(e.getCause().getCause() instanceof NumberFormatException,
+                    "Expected cause to be NumberFormatException, got: " + e.getCause().getCause());
+        }
     }
 
     @Test(description = "handleOTPResendCountExceededScenario with terminateFlow=true and user throws and sets " +

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPContextBasedRetryResendTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPContextBasedRetryResendTest.java
@@ -122,6 +122,7 @@ public class EmailOTPContextBasedRetryResendTest {
 
     @BeforeMethod
     public void setUp() {
+
         emailOTPAuthenticator = new TestEmailOTPAuthenticator();
         request = mock(HttpServletRequest.class);
         response = mock(HttpServletResponse.class);
@@ -159,6 +160,7 @@ public class EmailOTPContextBasedRetryResendTest {
 
     @AfterMethod
     public void tearDown() {
+
         if (staticConfigurationFacade != null) {
             staticConfigurationFacade.close();
         }

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPContextBasedRetryResendTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPContextBasedRetryResendTest.java
@@ -190,6 +190,16 @@ public class EmailOTPContextBasedRetryResendTest {
         }
     }
 
+    @org.testng.annotations.AfterClass
+    public void tearDownClass() {
+
+        // AuthenticatorDataHolder is a static singleton populated during these tests. Clear it
+        // at class teardown so the state does not leak into subsequent test classes
+        // (e.g. EmailOTPExecutorTest asserts these are null).
+        AuthenticatorDataHolder.setRealmService(null);
+        AuthenticatorDataHolder.setIdentityEventService(null);
+    }
+
     @Test(description = "Flow: initiateAuthenticationRequest with context-based resend limit exceeded " +
             "enforces resend limit and does not redirect to email OTP page")
     public void testInitiateAuthenticationRequest_ContextResendLimitExceeded_EnforcesLimit() throws Exception {

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPExecutorTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPExecutorTest.java
@@ -35,7 +35,6 @@ import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowUser;
 import org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants;
 import org.wso2.carbon.identity.local.auth.emailotp.constant.ExecutorConstants;
-import org.wso2.carbon.identity.local.auth.emailotp.internal.AuthenticatorDataHolder;
 import org.wso2.carbon.identity.local.auth.emailotp.util.CommonUtils;
 
 import java.lang.reflect.Field;
@@ -45,7 +44,6 @@ import java.util.List;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertThrows;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.EMAIL_ADDRESS_CLAIM;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.USERNAME_CLAIM;
 import static org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants.CODE;
@@ -191,10 +189,5 @@ public class EmailOTPExecutorTest {
 
         Assert.assertEquals(codeKeyField.get(props), expectedCodeKey);
         Assert.assertEquals(templateTypeField.get(props), expectedTemplateType);
-
-        assertThrows(IllegalStateException.class, AuthenticatorDataHolder::getRealmService);
-        assertThrows(IllegalStateException.class, AuthenticatorDataHolder::getAccountLockService);
-        assertThrows(IllegalStateException.class, AuthenticatorDataHolder::getIdentityGovernanceService);
-        assertThrows(IllegalStateException.class, AuthenticatorDataHolder::getIdpManager);
     }
 }


### PR DESCRIPTION
This PR addresses review comments on:

- [ ] https://github.com/wso2-extensions/identity-auth-otp-commons/pull/37

This pull request refactors the `EmailOTPAuthenticator` class to simplify exception handling and improve robustness when parsing numeric values from the authentication context. The main focus is to remove unnecessary checked exceptions, handle parsing errors gracefully, and update related method signatures and usages accordingly.

**Exception handling and robustness improvements:**

* Refactored multiple methods (such as `handleInvalidOTPLoginAttempt`, `handleOTPRetryCountExceededScenario`, `isOTPResendLimitExceededScenario`, `isOTPResendLimitExceeded`, `getMaximumRetryAttempts`, `isContextBasedOTPResendBlockingEnabled`, `isContextBasedRetryBlockingEnabled`, and `isTerminateOnResendLimitExceeded`) to remove `throws AuthenticationFailedException` from their signatures and internal calls, converting to unchecked exception handling and logging where appropriate. This reduces boilerplate and clarifies error handling. [[1]](diffhunk://#diff-7b06929a827c530ffcb8a7db8924fd24bad1f65cf6e45882f13435673b50c77bL2244-R2268) [[2]](diffhunk://#diff-7b06929a827c530ffcb8a7db8924fd24bad1f65cf6e45882f13435673b50c77bL2266-R2281) [[3]](diffhunk://#diff-7b06929a827c530ffcb8a7db8924fd24bad1f65cf6e45882f13435673b50c77bL2283-R2297) [[4]](diffhunk://#diff-7b06929a827c530ffcb8a7db8924fd24bad1f65cf6e45882f13435673b50c77bL2314-R2331) [[5]](diffhunk://#diff-7b06929a827c530ffcb8a7db8924fd24bad1f65cf6e45882f13435673b50c77bL2466-R2488) [[6]](diffhunk://#diff-7b06929a827c530ffcb8a7db8924fd24bad1f65cf6e45882f13435673b50c77bL2499-R2519) [[7]](diffhunk://#diff-7b06929a827c530ffcb8a7db8924fd24bad1f65cf6e45882f13435673b50c77bL2532-R2550)
* Updated all usages of `handleInvalidOTPLoginAttempt` to match the new signature (removed the `applicationTenantDomain` parameter), and updated related unit tests to match. [[1]](diffhunk://#diff-7b06929a827c530ffcb8a7db8924fd24bad1f65cf6e45882f13435673b50c77bL531-R531) [[2]](diffhunk://#diff-7b06929a827c530ffcb8a7db8924fd24bad1f65cf6e45882f13435673b50c77bL555-R555) [[3]](diffhunk://#diff-7b06929a827c530ffcb8a7db8924fd24bad1f65cf6e45882f13435673b50c77bL623-R623) [[4]](diffhunk://#diff-480a7bd6755e691bc36e547b9997caebc742aa251b7b9988b640b34a867861a8L695-R705)

**Context property parsing and error handling:**

* Added try-catch blocks around parsing context properties as integers (e.g., retry and resend attempt counts) to handle `NumberFormatException` gracefully. Logging is added in debug mode, and appropriate fallback logic is used (e.g., treating parse errors as exceeding limits). [[1]](diffhunk://#diff-7b06929a827c530ffcb8a7db8924fd24bad1f65cf6e45882f13435673b50c77bL2060-R2066) [[2]](diffhunk://#diff-7b06929a827c530ffcb8a7db8924fd24bad1f65cf6e45882f13435673b50c77bL2244-R2268) [[3]](diffhunk://#diff-7b06929a827c530ffcb8a7db8924fd24bad1f65cf6e45882f13435673b50c77bL2299-R2321) [[4]](diffhunk://#diff-7b06929a827c530ffcb8a7db8924fd24bad1f65cf6e45882f13435673b50c77bL2364-R2387)

**Minor cleanups and documentation:**

* Removed unnecessary or outdated JavaDoc comments, such as references to subclass overrides or thrown exceptions that no longer apply. [[1]](diffhunk://#diff-7b06929a827c530ffcb8a7db8924fd24bad1f65cf6e45882f13435673b50c77bL2428) [[2]](diffhunk://#diff-7b06929a827c530ffcb8a7db8924fd24bad1f65cf6e45882f13435673b50c77bL2439)
* Removed the unused constant `SKIP_RESEND_BLOCK_TIME` from `AuthenticatorConstants`.

**Diagnostic logging:**

* Updated diagnostic logging in `isContextBasedRetryBlockingEnabled` to use the correct service name constant (`EMAIL_OTP_SERVICE`) instead of `getName()`.