### PR TITLE
Count email otp reinitiation flow as resend flow

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
@@ -215,6 +215,28 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
         }
     }
 
+    /**
+     * Implicit reinitiation: silently re-triggers OTP generation with no submitted code, no RESEND
+     * flag, not a retry, and an OTP already issued in this context.
+     */
+    private boolean isImplicitOTPReinitiation(HttpServletRequest request, AuthenticationContext context) {
+
+        return !context.isRetrying()
+                && StringUtils.isBlank(request.getParameter(getCurrentCodeParam(request)))
+                && !Boolean.parseBoolean(request.getParameter(AuthenticatorConstants.RESEND))
+                && context.getProperty(AuthenticatorConstants.SENT_OTP_TOKEN_TIME_PREFIX + getName()) != null;
+    }
+
+    /**
+     * CountReinitiationsAsResends toggle. Defaults to true when unconfigured.
+     */
+    private boolean isCountReinitiationsAsResendsEnabled(AuthenticationContext context) {
+
+        Optional<Boolean> param = AuthenticatorUtils.getBooleanRuntimeParamByName(getRuntimeParams(context),
+                AuthenticatorConstants.COUNT_REINITIATIONS_AS_RESENDS);
+        return !param.isPresent() || param.get();
+    }
+
     @Override
     protected void initiateAuthenticationRequest(HttpServletRequest request,
                                                  HttpServletResponse response, AuthenticationContext context)
@@ -359,6 +381,14 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
             boolean shouldUpdateUserClaim = false;
             boolean isUserBasedResendLimitEnabled =
                     isUserBasedOTPResendBlockingEnabled(applicationTenantDomain, context) && isUserExists;
+            /*
+             * Implicit reinitiation looks should consume a resend slot when the toggle is on: check the limit before
+             * sending, increment only after a successful send.
+             */
+            boolean countAgainstResendLimit =
+                    scenario == AuthenticatorConstants.AuthenticationScenarios.RESEND_OTP
+                            || (isImplicitOTPReinitiation(request, context)
+                                    && isCountReinitiationsAsResendsEnabled(context));
             if (isUserBasedResendLimitEnabled) {
                 String userResendCountStr =
                         getUserClaimValueFromUserStore(EMAIL_OTP_RESEND_ATTEMPTS_CLAIM, mappedLocalUser,
@@ -396,16 +426,17 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                         }
                     }
                 }
-                if (scenario == AuthenticatorConstants.AuthenticationScenarios.RESEND_OTP) {
+                if (countAgainstResendLimit) {
                     otpResendCount++;
                     shouldUpdateUserClaim = true;
                 }
             }
 
-            if (isOTPResendLimitExceededScenario(scenario, context)) {
+            if (countAgainstResendLimit && isContextBasedOTPResendBlockingEnabled(context)
+                    && isOTPResendLimitExceeded(context)) {
                 handleOTPResendCountExceededScenario(request, response, context, authenticatingUser);
                 return;
-            } else if (scenario == AuthenticatorConstants.AuthenticationScenarios.RESEND_OTP) {
+            } else if (countAgainstResendLimit) {
                 updateContextOTPResendCount(context);
             }
 
@@ -413,6 +444,8 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
             try {
                 sendEmailOtp(email, applicationTenantDomain, authenticatedUserFromContext, scenario, context,
                         notifyOnEmailSendingFailure);
+                context.setProperty(AuthenticatorConstants.SENT_OTP_TOKEN_TIME_PREFIX + getName(),
+                        System.currentTimeMillis());
             } catch (AuthenticationFailedException e) {
                 String errorCode = e.getErrorCode();
                 if (!(notifyOnEmailSendingFailure

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticator.java
@@ -382,8 +382,10 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
             boolean isUserBasedResendLimitEnabled =
                     isUserBasedOTPResendBlockingEnabled(applicationTenantDomain, context) && isUserExists;
             /*
-             * Implicit reinitiation looks should consume a resend slot when the toggle is on: check the limit before
-             * sending, increment only after a successful send.
+             * Whether this send consumes a resend slot: always for an explicit RESEND_OTP, and for an implicit
+             * reinitiation when the CountReinitiationsAsResends toggle is on. The context resend counter is
+             * incremented before sending (as with RESEND_OTP); the user-store resend claim is persisted only
+             * after a successful send.
              */
             boolean countAgainstResendLimit =
                     scenario == AuthenticatorConstants.AuthenticationScenarios.RESEND_OTP

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/AuthenticatorConstants.java
@@ -61,6 +61,7 @@ public class AuthenticatorConstants {
     public static final String CODE_LOWERCASE = "OTPcode";
     public static final String DISPLAY_CODE = "Code";
     public static final String OTP_TOKEN = "otpToken";
+    public static final String SENT_OTP_TOKEN_TIME_PREFIX = "sentOtpTokenTime.";
     public static final String EMAIL_OTP_TEMPLATE_NAME = "EmailOTP";
     public static final String RESEND_EMAIL_OTP_TEMPLATE_NAME = "ResendEmailOTP";
     public static final String LOCAL_CLAIM_VALUE = "locale";
@@ -119,6 +120,7 @@ public class AuthenticatorConstants {
     // Runtime Params.
     public static final String MAXIMUM_ALLOWED_FAILURE_LIMIT = "maximumAllowedFailureAttempts";
     public static final String MAXIMUM_RESEND_LIMIT = "maximumAllowedResendAttempts";
+    public static final String COUNT_REINITIATIONS_AS_RESENDS = "CountReinitiationsAsResends";
     public static final String SKIP_RESEND_BLOCK_TIME = "skipResendBlockTime";
     public static final String TERMINATE_ON_RESEND_LIMIT_EXCEEDED = "terminateOnResendLimitExceeded";
 

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPAuthenticatorTest.java
@@ -90,6 +90,7 @@ import javax.servlet.http.HttpServletResponse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -243,6 +244,27 @@ public class EmailOTPAuthenticatorTest {
                 {AuthenticatorConstants.CODE},
                 {AuthenticatorConstants.CODE_LOWERCASE}
         };
+    }
+
+    @DataProvider
+    public Object[][] countReinitiationsAsResendsDataProvider() {
+
+        return new Object[][]{
+                {Optional.empty(), true},
+                {Optional.of(Boolean.TRUE), true},
+                {Optional.of(Boolean.FALSE), false}
+        };
+    }
+
+    @Test(dataProvider = "countReinitiationsAsResendsDataProvider")
+    public void testIsCountReinitiationsAsResendsEnabled(Optional<Boolean> param, boolean expected) throws Exception {
+
+        authenticatorUtils.when(() -> AuthenticatorUtils.getBooleanRuntimeParamByName(any(),
+                eq(AuthenticatorConstants.COUNT_REINITIATIONS_AS_RESENDS))).thenReturn(param);
+        Method method = EmailOTPAuthenticator.class
+                .getDeclaredMethod("isCountReinitiationsAsResendsEnabled", AuthenticationContext.class);
+        method.setAccessible(true);
+        Assert.assertEquals(method.invoke(emailOTPAuthenticator, new AuthenticationContext()), expected);
     }
 
     @Test(description = "Test case for getParameterNames() method.", dataProvider = "OTPParams")

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPContextBasedRetryResendTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPContextBasedRetryResendTest.java
@@ -268,6 +268,149 @@ public class EmailOTPContextBasedRetryResendTest {
         Assert.assertNull(redirectToOtp, "Should not redirect to OTP page when resend limit exceeded");
     }
 
+    @Test(description = "Flow: implicit reinit (no CODE, no RESEND, OTP_TOKEN set, !isRetrying, toggle on) "
+            + "bumps the context resend counter via the context-path")
+    public void testInitiateAuthenticationRequest_ImplicitReinit_ContextPath_BumpsResendCount() throws Exception {
+
+        Map<String, String> params = new HashMap<>();
+        params.put(MAXIMUM_RESEND_LIMIT, "5");
+        params.put(AuthenticatorConstants.COUNT_REINITIATIONS_AS_RESENDS, "true");
+        addRuntimeParamsToContext(params);
+        context.setTenantDomain(TENANT_DOMAIN);
+        context.setRetrying(false);
+        context.setCurrentAuthenticator(EMAIL_OTP_AUTHENTICATOR_NAME);
+        context.setProperty(AuthenticatorConstants.OTP_TOKEN, "000000");
+        context.setProperty(AuthenticatorConstants.SENT_OTP_TOKEN_TIME_PREFIX + EMAIL_OTP_AUTHENTICATOR_NAME,
+                System.currentTimeMillis());
+        context.setProperty(EMAIL_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME, 0);
+
+        when(request.getParameter(AuthenticatorConstants.RESEND)).thenReturn(null);
+        when(request.getParameter(AuthenticatorConstants.CODE)).thenReturn(null);
+        when(request.getParameter(AuthenticatorConstants.CODE_LOWERCASE)).thenReturn(null);
+        when(request.getParameter(AuthenticatorConstants.USER_NAME)).thenReturn(USERNAME);
+
+        setStepConfigWithEmailOTPAuthenticator(context);
+        when(ConfigurationFacade.getInstance()).thenReturn(configurationFacade);
+        when(configurationFacade.getAuthenticationEndpointURL()).thenReturn(DUMMY_LOGIN_PAGE_URL);
+        when(FileBasedConfigurationBuilder.getInstance()).thenReturn(fileBasedConfigurationBuilder);
+        when(FrameworkServiceDataHolder.getInstance()).thenReturn(frameworkServiceDataHolder);
+        when(frameworkServiceDataHolder.getRealmService()).thenReturn(realmService);
+        when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
+        when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
+
+        AuthenticatedUser subject = new AuthenticatedUser();
+        subject.setUserName(USERNAME);
+        subject.setTenantDomain(TENANT_DOMAIN);
+        subject.setUserStoreDomain(USER_STORE_DOMAIN);
+        subject.setUserId(USER_ID);
+        context.setSubject(subject);
+
+        User user = new User(UUID.randomUUID().toString(), USERNAME, null);
+        user.setUserStoreDomain(USER_STORE_DOMAIN);
+        user.setTenantDomain(TENANT_DOMAIN);
+        List<User> userList = new ArrayList<>();
+        userList.add(user);
+        Map<String, String> claimMap = new HashMap<>();
+        claimMap.put(EMAIL_ADDRESS_CLAIM, EMAIL_ADDRESS);
+        claimMap.put(EMAIL_OTP_RESEND_ATTEMPTS_CLAIM, "0");
+        claimMap.put(EMAIL_OTP_LAST_SENT_TIME_CLAIM, String.valueOf(System.currentTimeMillis()));
+
+        when(userStoreManager.getUserListWithID(USERNAME_CLAIM, USERNAME, null)).thenReturn(userList);
+        when(userStoreManager.getUserClaimValues(any(), any(), any())).thenReturn(claimMap);
+        when(userStoreManager.getSecondaryUserStoreManager(anyString())).thenReturn(userStoreManager);
+        userCoreUtil.when(() -> UserCoreUtil.getDomainFromThreadLocal()).thenReturn(DEFAULT_USER_STORE);
+
+        authenticatorUtils.when(() ->
+                AuthenticatorUtils.getEmailAuthenticatorConfig(
+                        AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_RESEND_ATTEMPTS_COUNT,
+                        TENANT_DOMAIN)).thenReturn("0");
+        authenticatorUtils.when(() ->
+                AuthenticatorUtils.getEmailOTPLoginPageUrl(any(), anyString())).thenReturn(DUMMY_LOGIN_PAGE_URL);
+        when(FileBasedConfigurationBuilder.getInstance().getAuthenticatorBean(anyString()))
+                .thenReturn(getAuthenticatorConfig());
+        AuthenticatorDataHolder.setRealmService(realmService);
+
+        Method method = findMethod(EmailOTPAuthenticator.class, "initiateAuthenticationRequest",
+                new Class[]{HttpServletRequest.class, HttpServletResponse.class, AuthenticationContext.class});
+        try {
+            method.invoke(emailOTPAuthenticator, request, response, context);
+        } catch (InvocationTargetException ignored) {
+        }
+
+        Object resendCount = context.getProperty(EMAIL_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME);
+        assertNotNull(resendCount, "Context resend count should be updated on implicit reinit when toggle on");
+        assertEquals(((Number) resendCount).intValue(), 1, "Resend count should bump from 0 to 1");
+    }
+
+    @Test(description = "Flow: implicit reinit with toggle off does NOT bump the context resend counter")
+    public void testInitiateAuthenticationRequest_ImplicitReinit_ToggleOff_NoBump() throws Exception {
+
+        Map<String, String> params = new HashMap<>();
+        params.put(MAXIMUM_RESEND_LIMIT, "5");
+        params.put(AuthenticatorConstants.COUNT_REINITIATIONS_AS_RESENDS, "false");
+        addRuntimeParamsToContext(params);
+        context.setTenantDomain(TENANT_DOMAIN);
+        context.setRetrying(false);
+        context.setCurrentAuthenticator(EMAIL_OTP_AUTHENTICATOR_NAME);
+        context.setProperty(AuthenticatorConstants.OTP_TOKEN, "000000");
+        context.setProperty(AuthenticatorConstants.SENT_OTP_TOKEN_TIME_PREFIX + EMAIL_OTP_AUTHENTICATOR_NAME,
+                System.currentTimeMillis());
+        context.setProperty(EMAIL_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME, 0);
+
+        when(request.getParameter(AuthenticatorConstants.RESEND)).thenReturn(null);
+        when(request.getParameter(AuthenticatorConstants.CODE)).thenReturn(null);
+        when(request.getParameter(AuthenticatorConstants.CODE_LOWERCASE)).thenReturn(null);
+        when(request.getParameter(AuthenticatorConstants.USER_NAME)).thenReturn(USERNAME);
+
+        setStepConfigWithEmailOTPAuthenticator(context);
+        when(ConfigurationFacade.getInstance()).thenReturn(configurationFacade);
+        when(configurationFacade.getAuthenticationEndpointURL()).thenReturn(DUMMY_LOGIN_PAGE_URL);
+        when(FileBasedConfigurationBuilder.getInstance()).thenReturn(fileBasedConfigurationBuilder);
+        when(FrameworkServiceDataHolder.getInstance()).thenReturn(frameworkServiceDataHolder);
+        when(frameworkServiceDataHolder.getRealmService()).thenReturn(realmService);
+        when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
+        when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
+
+        AuthenticatedUser subject = new AuthenticatedUser();
+        subject.setUserName(USERNAME);
+        subject.setTenantDomain(TENANT_DOMAIN);
+        subject.setUserStoreDomain(USER_STORE_DOMAIN);
+        subject.setUserId(USER_ID);
+        context.setSubject(subject);
+
+        User user = new User(UUID.randomUUID().toString(), USERNAME, null);
+        user.setUserStoreDomain(USER_STORE_DOMAIN);
+        user.setTenantDomain(TENANT_DOMAIN);
+        List<User> userList = new ArrayList<>();
+        userList.add(user);
+        Map<String, String> claimMap = new HashMap<>();
+        claimMap.put(EMAIL_ADDRESS_CLAIM, EMAIL_ADDRESS);
+        when(userStoreManager.getUserListWithID(USERNAME_CLAIM, USERNAME, null)).thenReturn(userList);
+        when(userStoreManager.getUserClaimValues(any(), any(), any())).thenReturn(claimMap);
+        when(userStoreManager.getSecondaryUserStoreManager(anyString())).thenReturn(userStoreManager);
+        userCoreUtil.when(() -> UserCoreUtil.getDomainFromThreadLocal()).thenReturn(DEFAULT_USER_STORE);
+
+        authenticatorUtils.when(() ->
+                AuthenticatorUtils.getEmailAuthenticatorConfig(
+                        AuthenticatorConstants.ConnectorConfig.EMAIL_OTP_RESEND_ATTEMPTS_COUNT,
+                        TENANT_DOMAIN)).thenReturn("0");
+        authenticatorUtils.when(() ->
+                AuthenticatorUtils.getEmailOTPLoginPageUrl(any(), anyString())).thenReturn(DUMMY_LOGIN_PAGE_URL);
+        when(FileBasedConfigurationBuilder.getInstance().getAuthenticatorBean(anyString()))
+                .thenReturn(getAuthenticatorConfig());
+        AuthenticatorDataHolder.setRealmService(realmService);
+
+        Method method = findMethod(EmailOTPAuthenticator.class, "initiateAuthenticationRequest",
+                new Class[]{HttpServletRequest.class, HttpServletResponse.class, AuthenticationContext.class});
+        try {
+            method.invoke(emailOTPAuthenticator, request, response, context);
+        } catch (InvocationTargetException ignored) {
+        }
+
+        Object resendCount = context.getProperty(EMAIL_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME);
+        assertEquals(((Number) resendCount).intValue(), 0, "Resend count should remain 0 when toggle off");
+    }
+
     @Test(description = "Flow: initiateAuthenticationRequest with context-based resend under limit " +
             "allows resend and updates context resend count")
     public void testInitiateAuthenticationRequest_ContextResendUnderLimit_UpdatesResendCount() throws Exception {

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPContextBasedRetryResendTest.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/test/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPContextBasedRetryResendTest.java
@@ -39,8 +39,10 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.util.IdentityConfigParser;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.local.auth.emailotp.constant.AuthenticatorConstants;
 import org.wso2.carbon.identity.local.auth.emailotp.internal.AuthenticatorDataHolder;
 import org.wso2.carbon.identity.local.auth.emailotp.util.AuthenticatorUtils;
@@ -119,6 +121,7 @@ public class EmailOTPContextBasedRetryResendTest {
     private MockedStatic<LoggerUtils> loggerUtils;
     private MockedStatic<UserCoreUtil> userCoreUtil;
     private MockedStatic<IdentityTenantUtil> identityTenantUtil;
+    private MockedStatic<IdentityConfigParser> identityConfigParser;
 
     @BeforeMethod
     public void setUp() {
@@ -143,6 +146,11 @@ public class EmailOTPContextBasedRetryResendTest {
         loggerUtils = mockStatic(LoggerUtils.class);
         userCoreUtil = mockStatic(UserCoreUtil.class, Mockito.CALLS_REAL_METHODS);
         identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+        identityConfigParser = mockStatic(IdentityConfigParser.class);
+
+        IdentityConfigParser identityConfigParserInstance = mock(IdentityConfigParser.class);
+        identityConfigParser.when(IdentityConfigParser::getInstance).thenReturn(identityConfigParserInstance);
+        when(identityConfigParserInstance.getConfiguration()).thenReturn(new HashMap<>());
 
         loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(false);
         identityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(TENANT_DOMAIN)).thenReturn(-1234);
@@ -155,6 +163,7 @@ public class EmailOTPContextBasedRetryResendTest {
         authenticatorUtils.when(() -> AuthenticatorUtils.getBooleanRuntimeParamByName(any(), anyString()))
                 .thenCallRealMethod();
         AuthenticatorDataHolder.setIdentityEventService(mock(IdentityEventService.class));
+        AuthenticatorDataHolder.setIdentityGovernanceService(mock(IdentityGovernanceService.class));
     }
 
     @AfterMethod
@@ -185,6 +194,9 @@ public class EmailOTPContextBasedRetryResendTest {
         }
         if (identityTenantUtil != null) {
             identityTenantUtil.close();
+        }
+        if (identityConfigParser != null) {
+            identityConfigParser.close();
         }
     }
 
@@ -332,10 +344,7 @@ public class EmailOTPContextBasedRetryResendTest {
 
         Method method = findMethod(EmailOTPAuthenticator.class, "initiateAuthenticationRequest",
                 new Class[]{HttpServletRequest.class, HttpServletResponse.class, AuthenticationContext.class});
-        try {
-            method.invoke(emailOTPAuthenticator, request, response, context);
-        } catch (InvocationTargetException ignored) {
-        }
+        invokeInitiateExpectingRedirect(method);
 
         Object resendCount = context.getProperty(EMAIL_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME);
         assertNotNull(resendCount, "Context resend count should be updated on implicit reinit when toggle on");
@@ -402,10 +411,7 @@ public class EmailOTPContextBasedRetryResendTest {
 
         Method method = findMethod(EmailOTPAuthenticator.class, "initiateAuthenticationRequest",
                 new Class[]{HttpServletRequest.class, HttpServletResponse.class, AuthenticationContext.class});
-        try {
-            method.invoke(emailOTPAuthenticator, request, response, context);
-        } catch (InvocationTargetException ignored) {
-        }
+        invokeInitiateExpectingRedirect(method);
 
         Object resendCount = context.getProperty(EMAIL_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME);
         assertEquals(((Number) resendCount).intValue(), 0, "Resend count should remain 0 when toggle off");
@@ -467,10 +473,7 @@ public class EmailOTPContextBasedRetryResendTest {
         Method method = findMethod(EmailOTPAuthenticator.class, "initiateAuthenticationRequest",
                 new Class[]{HttpServletRequest.class, HttpServletResponse.class, AuthenticationContext.class});
 
-        try {
-            method.invoke(emailOTPAuthenticator, request, response, context);
-        } catch (InvocationTargetException ignored) {
-        }
+        invokeInitiateExpectingRedirect(method);
 
         // Resend count should have been incremented (RESEND_OTP scenario)
         Object resendCount = context.getProperty(EMAIL_OTP_RESEND_ATTEMPTS_CONTEXT_PROPERTY_NAME);
@@ -953,6 +956,24 @@ public class EmailOTPContextBasedRetryResendTest {
         } catch (NoSuchMethodException e) {
             if (clazz.getSuperclass() != null) {
                 return findMethod(clazz.getSuperclass(), name, paramTypes);
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Invokes initiateAuthenticationRequest for flows that are expected to redirect and complete without throwing.
+     * Any InvocationTargetException is unwrapped and rethrown so a genuine flow failure fails the test instead of
+     * being silently swallowed (which would let assertions pass against pre-set property values).
+     */
+    private void invokeInitiateExpectingRedirect(Method method) throws Exception {
+
+        try {
+            method.invoke(emailOTPAuthenticator, request, response, context);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof Exception) {
+                throw (Exception) cause;
             }
             throw e;
         }


### PR DESCRIPTION
This pull request enhances the Email OTP authenticator to treat implicit reinitiations (when an OTP is silently regenerated without explicit user action) as resend attempts, depending on a new configurable toggle. It also adds comprehensive tests to ensure the correct behavior for both enabled and disabled states of this feature.

**Email OTP Resend Logic Improvements:**

* Added logic to detect implicit OTP reinitiation and, when the new `CountReinitiationsAsResends` toggle is enabled (defaulting to true), count these as resend attempts against the resend limit. This helps prevent abuse by limiting silent OTP regenerations. [[1]](diffhunk://#diff-7b06929a827c530ffcb8a7db8924fd24bad1f65cf6e45882f13435673b50c77bR218-R240) [[2]](diffhunk://#diff-7b06929a827c530ffcb8a7db8924fd24bad1f65cf6e45882f13435673b50c77bR385-R392) [[3]](diffhunk://#diff-7b06929a827c530ffcb8a7db8924fd24bad1f65cf6e45882f13435673b50c77bL399-R449)
* Introduced the `SENT_OTP_TOKEN_TIME_PREFIX` and `COUNT_REINITIATIONS_AS_RESENDS` constants to support the new logic. [[1]](diffhunk://#diff-4e77163152a0c9ef78ab77cb2bddd757be88f96bc337b6cdcbdd4aae39be6c20R64) [[2]](diffhunk://#diff-4e77163152a0c9ef78ab77cb2bddd757be88f96bc337b6cdcbdd4aae39be6c20R123)

**Testing Enhancements:**

* Added unit tests to verify the toggle logic for counting implicit reinitiations as resends.
* Added integration tests to ensure that implicit reinitiation correctly increments the resend counter when the toggle is on, and does not when the toggle is off.

**Test Utility Updates:**

* Minor improvements to test imports for better argument matching.

### Related PRs
- https://github.com/wso2-extensions/identity-auth-otp-commons/pull/44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a configurable setting (`COUNT_REINITIATIONS_AS_RESENDS`) to treat implicit OTP re-requests as resend attempts against rate limits, defaulting to enabled for improved abuse protection.

* **Tests**
  * Added comprehensive test cases validating implicit OTP reinitiation behavior with the new configuration toggle in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->