### PR TITLE
Add device registration flow support to the Email OTP executor

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPExecutor.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPExecutor.java
@@ -55,6 +55,7 @@ public class EmailOTPExecutor extends AbstractOTPExecutor {
     private static final String PASSWORD_RECOVERY = "PASSWORD_RECOVERY";
     private static final String REGISTRATION = "REGISTRATION";
     private static final String ASK_PASSWORD = "INVITED_USER_REGISTRATION";
+    private static final String DEVICE_REGISTRATION = "DEVICE_REGISTRATION";
 
     @Override
     public String getName() {
@@ -196,6 +197,8 @@ public class EmailOTPExecutor extends AbstractOTPExecutor {
             case REGISTRATION:
             case ASK_PASSWORD:
                 return new FlowTypeProperties(CODE, ExecutorConstants.EMAIL_OTP_VERIFY_TEMPLATE);
+            case DEVICE_REGISTRATION:
+                return new FlowTypeProperties(CODE, ExecutorConstants.EMAIL_OTP_DEVICE_REGISTRATION_TEMPLATE);
             case PASSWORD_RECOVERY:
                 return new FlowTypeProperties(CONFIRMATION_CODE, ExecutorConstants.EMAIL_OTP_PASSWORD_RESET_TEMPLATE);
             default:

--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/ExecutorConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/constant/ExecutorConstants.java
@@ -29,6 +29,7 @@ public class ExecutorConstants {
 
     public static final String EMAIL_OTP_EXECUTOR_NAME = "EmailOTPExecutor";
     public static final String EMAIL_OTP_VERIFY_TEMPLATE = "EmailOTPVerification";
+    public static final String EMAIL_OTP_DEVICE_REGISTRATION_TEMPLATE = "EmailOTPDeviceRegistration";
     public static final String EMAIL_OTP_PASSWORD_RESET_TEMPLATE = "passwordResetOTP";
     public static final String EMAIL_VERIFIED_CLAIM_URI = "http://wso2.org/claims/identity/emailVerified";
     public static final String VERIFIED_EMAIL_ADDRESSES_CLAIM_URI = "http://wso2.org/claims/verifiedEmailAddresses";


### PR DESCRIPTION
# Proposed changes in this pull request

Adds a `DEVICE_REGISTRATION` constant to `EmailOTPExecutor` and includes it in the existing `resolveFlowTypeProperties(...)` switch


### Usage

N/A

### Testing

N/A

## When should this PR be merged

This change depends on the `DEVICE_REGISTRATION` flow type being available in `org.wso2.carbon.identity.flow.mgt`

## Follow up actions

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for email OTP verification during device registration flows.
  * Introduced a dedicated device registration email template for one-time passcodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->