### PR TITLE
Add username and userstore domain to the OTP event data

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPExecutor.java
+++ b/components/org.wso2.carbon.identity.local.auth.emailotp/src/main/java/org/wso2/carbon/identity/local/auth/emailotp/EmailOTPExecutor.java
@@ -95,6 +95,10 @@ public class EmailOTPExecutor extends AbstractOTPExecutor {
         eventProperties.put(NotificationConstants.EmailNotification.EMAIL_TEMPLATE_TYPE, flowProperties.templateType);
         eventProperties.put(NotificationConstants.ARBITRARY_SEND_TO, email);
         eventProperties.put(NotificationConstants.TENANT_DOMAIN, tenantDomain);
+        eventProperties.put(IdentityEventConstants.EventProperty.USER_NAME, context.getFlowUser().getUsername());
+        eventProperties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, context.getFlowUser().
+                getUserStoreDomain());
+
         if (StringUtils.isNotBlank(context.getApplicationId())) {
             eventProperties.put(IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID,
                     context.getApplicationId());


### PR DESCRIPTION
## Purpose
- $subject since this userstore domain is used to extract the user claims in [1] so that the code can get the user's configured locale value and extract the corresponding email template.

[1] https://github.com/wso2-extensions/identity-event-handler-notification/blob/12fed10b72f5701afe36cebca101d82ef62bd15e/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java#L725

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notification events now include the flow user’s username and user-store domain alongside existing OTP and account details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->